### PR TITLE
Add pkg-config support

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -83,6 +83,13 @@ set_target_properties( clFFT PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINA
 if( UNIX )
 	# Right now, linux has problems compiling dynamic_cast, but the flag below doesn't help
 	# set_target_properties( clFFT PROPERTIES COMPILE_FLAGS "-frtti" )
+
+    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/clFFT.pc.in
+                    ${CMAKE_CURRENT_BINARY_DIR}/clFFT.pc @ONLY IMMEDIATE )
+
+    install( FILES ${CMAKE_CURRENT_BINARY_DIR}/clFFT.pc
+             DESTINATION lib/pkgconfig
+           )
 endif( )
 
 if( BUILD64 )

--- a/src/library/clFFT.pc.in
+++ b/src/library/clFFT.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: clFFT
+Description: OpenCL FFT library
+Version: @CLFFT_VERSION@
+
+Libs: -L${libdir} -lclFFT
+Cflags: -I${includedir}


### PR DESCRIPTION
pkg-config is the de-facto standard to gather compiler and linker flags for libraries. This change adds a pkgconfig description file and installs it.
