### PR TITLE
Adding mingw32 support as a compilation platform

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -208,8 +208,8 @@ else( )
 	message( FATAL_ERROR "Compiler name not detected" )
 endif( )
 
-# If UNICODE is defined, pass extra definitions into 
-if( UNICODE )
+# If UNICODE is defined for microsoft compilers, pass extra definitions
+if( MSVC AND UNICODE )
 	add_definitions( "/DUNICODE /D_UNICODE" )
 endif( )
 

--- a/src/client/openCL.misc.h
+++ b/src/client/openCL.misc.h
@@ -23,7 +23,7 @@
 #include "unicode.compatibility.h"
 
 //	Creating a portable defintion of countof
-#if defined( _WIN32 )
+#if defined( _MSC_VER )
 	#define countOf _countof
 #else
 	#define countOf( arr ) ( sizeof( arr ) / sizeof( arr[ 0 ] ) )

--- a/src/include/sharedLibrary.h
+++ b/src/include/sharedLibrary.h
@@ -79,7 +79,7 @@ inline void* LoadFunctionAddr( void* libHandle, std::string funcName )
 #if defined( _WIN32 )
 	HMODULE fileHandle = reinterpret_cast< HMODULE >( libHandle );
 
-	void* pFunc	= ::GetProcAddress( fileHandle, funcName.c_str( ) );
+	void* pFunc	= reinterpret_cast< void* >( ::GetProcAddress( fileHandle, funcName.c_str( ) ) );
 #else
 	void* pFunc = ::dlsym( libHandle, funcName.c_str( ) );
 #endif

--- a/src/include/stdafx.h
+++ b/src/include/stdafx.h
@@ -42,8 +42,11 @@
 	#include <tchar.h>
 	#include "targetver.h"
 
+#if !defined( NOMINMAX )
 	#define NOMINMAX
-	#define WIN32_LEAN_AND_MEAN			// Exclude rarely-used stuff from Windows headers
+#endif
+
+    #define WIN32_LEAN_AND_MEAN			// Exclude rarely-used stuff from Windows headers
 	// Windows Header Files:
 	#include <windows.h>
 #endif

--- a/src/library/private.h
+++ b/src/library/private.h
@@ -46,13 +46,15 @@
 #endif
 
 //	Creating a portable defintion of countof
-#if defined( _WIN32 )
+//  This excludes mingw compilers; mingw32 does not have _countof
+#if defined( _MSC_VER )
 	#define countOf _countof
 #else
 	#define countOf( arr ) ( sizeof( arr ) / sizeof( arr[ 0 ] ) )
 #endif
 
-#if defined( _WIN32 )
+// This excludes mingw compilers; mingw32 does not have <intrin.h>
+#if defined( _MSC_VER )
 	#include <intrin.h>
 
 	#if defined( _WIN64 )

--- a/src/statTimer/statisticalTimer.CPU.h
+++ b/src/statTimer/statisticalTimer.CPU.h
@@ -47,7 +47,8 @@ class CpuStatTimer : public baseStatTimer
 	cl_ulong	clkFrequency;
 
 	//	For linux; the resolution of a high-precision timer
-#if defined( __GNUC__ )
+	//  Mingw32 does not define timespec; can use windows timers
+#if !defined( _WIN32 )
 	timespec res;
 #endif
 

--- a/src/statTimer/stdafx.h
+++ b/src/statTimer/stdafx.h
@@ -41,7 +41,10 @@
 //	#include <tchar.h>
 	#include "targetver.h"
 
+#if !defined( NOMINMAX )
 	#define NOMINMAX
+#endif
+
 	#define WIN32_LEAN_AND_MEAN			// Exclude rarely-used stuff from Windows headers
 	// Windows Header Files:
 	#include <windows.h>

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -50,7 +50,11 @@ set( clFFT.Test.Headers
 set( clFFT.Test.Files ${clFFT.Test.Source} ${clFFT.Test.Headers} )
 
 set( LD_PTHREAD "" )
-if( CMAKE_COMPILER_IS_GNUCXX )
+if( MINGW )
+    # -std=c++0x causes g++ to go into strict ANSI mode, which doesn't declare non-standard functions
+    # Googletest for mingw appears to have a dependency on _stricmp and off64_t
+	set( CMAKE_CXX_FLAGS "-std=gnu++0x ${CMAKE_CXX_FLAGS}" )
+elseif( CMAKE_COMPILER_IS_GNUCXX )
 	set( CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS}" )
 	set( LD_PTHREAD "-lpthread" )
 endif( )

--- a/src/tests/gtest_main.cpp
+++ b/src/tests/gtest_main.cpp
@@ -29,8 +29,10 @@ time_t random_test_parameter_seed;
 float tolerance;
 bool verbose;
 
-#if defined( _WIN32 )
-#define NOMINMAX
+#if defined( MSVC_VER )
+#if !defined( NOMINMAX )
+	#define NOMINMAX
+#endif
 #define WIN32_LEAN_AND_MEAN			// Exclude rarely-used stuff from Windows headers
 #include <intrin.h>
 

--- a/src/tests/test_constants.cpp
+++ b/src/tests/test_constants.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  * ************************************************************************/
 
-
 #include "test_constants.h"
 #include <gtest/gtest.h>
 #include <stdexcept>


### PR DESCRIPTION
closes #11 enhancement request
This has been tested to build and run on windows/linux/mingw
