### PR TITLE
Adding CUDA_PATH as an OPENCL_ROOT option 

### DIFF
--- a/src/FindOpenCL.cmake
+++ b/src/FindOpenCL.cmake
@@ -85,7 +85,7 @@ else( )
 			${OPENCL_ROOT}/lib
 			ENV AMDAPPSDKROOT/lib
 		DOC "OpenCL dynamic library path"
-		PATH_SUFFIXES x86
+		PATH_SUFFIXES x86 Win32
 	)
 endif( )
 mark_as_advanced( OPENCL_LIBRARIES )


### PR DESCRIPTION
This is the first step to make the build process vendor independent. 
