### PR TITLE
Logic added to packaging step 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 clFFT
 =====
+[![Build Status](https://travis-ci.org/clMathLibraries/clFFT.png)](https://travis-ci.org/clMathLibraries/clFFT)
 
 clMath is a software library containing FFT and BLAS functions written in OpenCL. In addition to GPU devices, the libraries also support running on CPU devices to facilitate debugging and multicore programming.
 
 <a href="http://developer.amd.com/tools-and-sdks/heterogeneous-computing/amd-accelerated-parallel-processing-math-libraries/">APPML 1.10</a> is the most current generally available version of the library, and pre-built binaries are available for download on both Linux and Windows platforms.
 
-[![Build Status](https://travis-ci.org/kknox/clFFT.png)](https://travis-ci.org/kknox/clFFT)
 ## Introduction to clFFT
 
 The FFT is an implementation of the Discrete Fourier Transform (DFT) that makes use of symmetries in the FFT definition to reduce the mathematical intensity required from O(N<sup>2</sup>) to O(N log<sub>2</sub>( N )) when the sequence length N is the product of small prime factors. Currently, there is no standard API for FFT routines. Hardware vendors usually provide a set of high-performance FFTs optimized for their systems: no two vendors employ the same interfaces for their FFT routines. clFFT provides a set of FFT routines that are optimized for AMD graphics processors, but also are functional across CPU and other compute devices.

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -95,3 +95,34 @@ install( TARGETS clFFT
         LIBRARY DESTINATION lib${SUFFIX_LIB}
         ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
         )
+        
+# For debug builds, include the debug runtimes into the package for testing on non-developer machines
+set( CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP true )
+set( CMAKE_INSTALL_DEBUG_LIBRARIES true )
+set( CMAKE_INSTALL_DEBUG_LIBRARIES_ONLY true )
+
+if( WIN32 )
+    set( CLFFT_RUNTIME_DESTINATION bin${SUFFIX_BIN} )
+else( )
+    set( CLFFT_RUNTIME_DESTINATION lib${SUFFIX_LIB} )
+endif( )
+
+include( InstallRequiredSystemLibraries )
+
+# Install necessary runtime files for debug builds
+install(    PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
+            CONFIGURATIONS Debug
+            DESTINATION ${CLFFT_RUNTIME_DESTINATION} )
+
+# Install all *.pdb files for debug builds
+install(    DIRECTORY ${PROJECT_BINARY_DIR}/staging/
+            DESTINATION ${CLFFT_RUNTIME_DESTINATION}
+            OPTIONAL
+            CONFIGURATIONS Debug
+            FILES_MATCHING PATTERN "*.pdb" )
+
+# Install a snapshot of the source as it was for this build; useful for the .pdb's
+install(    DIRECTORY ${PROJECT_SOURCE_DIR}
+            DESTINATION ${CLFFT_RUNTIME_DESTINATION}
+            OPTIONAL
+            CONFIGURATIONS Debug )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -104,3 +104,15 @@ install( TARGETS Test
         LIBRARY DESTINATION lib${SUFFIX_LIB}
         ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
         )
+
+get_target_property( testLocation Test LOCATION )
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/copyTestDependencies.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/copyTestDependencies.cmake"
+    @ONLY
+)
+
+# Register script at run at install time to analyze the executable and copy dependencies into package
+install( SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/copyTestDependencies.cmake")
+ 

--- a/src/tests/copyTestDependencies.cmake.in
+++ b/src/tests/copyTestDependencies.cmake.in
@@ -1,0 +1,72 @@
+# Customized install script for fftw test program; analyzes all the shared library dependencies and installs
+# the dependencies into the package
+include( GetPrerequisites )
+
+#    message( testLocation ": @testLocation@" )
+
+# The Microsoft IDE presents a challenge because the full configuration is not known at cmake time
+# This logic allows us to 'substitute' the proper confguration at install time
+if( "${CMAKE_INSTALL_CONFIG_NAME}" MATCHES "Debug" )
+    string( REPLACE "\$(Configuration)" "Debug" fixedTestLocation "@testLocation@" )
+elseif( "${CMAKE_INSTALL_CONFIG_NAME}" MATCHES "Release" )
+    string( REPLACE "\$(Configuration)" "Release" fixedTestLocation "@testLocation@" )
+elseif( "${CMAKE_INSTALL_CONFIG_NAME}" MATCHES "MinSizeRel" )
+    string( REPLACE "\$(Configuration)" "MinSizeRel" fixedTestLocation "@testLocation@" )
+elseif( "${CMAKE_INSTALL_CONFIG_NAME}" MATCHES "RelwithDebInfo" )
+    string( REPLACE "\$(Configuration)" "RelwithDebInfo" fixedTestLocation "@testLocation@" )
+endif( )
+
+#    message( fixedTestLocation ": ${fixedTestLocation}" )
+# Get the directory that the test executable resides in; this helps get_prerequisites( ) find dependent libraries
+get_filename_component( testName "${fixedTestLocation}" NAME )
+string( REPLACE ${testName} "" testDir ${fixedTestLocation} )
+string( REGEX REPLACE "/+$" "" testDir ${testDir} )
+#    message( testDir ": ${testDir}" )
+
+set( installPath "" )
+if( WIN32 )
+    set( installPath "${CMAKE_INSTALL_PREFIX}/bin@SUFFIX_BIN@" )
+else( )
+    set( installPath "${CMAKE_INSTALL_PREFIX}/lib@SUFFIX_LIB@" )
+endif( )
+
+# Only search for dependencies that have ROOT defined
+set( depList "" )
+
+if( EXISTS "@FFTW_ROOT@" )
+    list( APPEND depList "@FFTW_ROOT@/lib@SUFFIX_LIB@" )
+endif( )
+
+if( EXISTS "@GTEST_ROOT@" )
+    list( APPEND depList "@GTEST_ROOT@/lib@SUFFIX_LIB@" )
+endif( )
+
+if( EXISTS "${testDir}" )
+    list( APPEND depList "${testDir}" )
+endif( )
+
+# message( STATUS "depList: ${depList}" )
+
+# This retrieves a list of shared library dependencies from the target; they are not full path names
+# Skip system dependencies and skip recursion
+get_prerequisites( ${fixedTestLocation} testDependencies 1 0 "" "${depList}" )
+
+# Loop on queried library dependencies and copy them into package
+foreach( dep ${testDependencies} )
+    # This converts the dependency into a full path
+    gp_resolve_item( "${fixedTestLocation}" "${dep}" "" "${depList}" dep_test_path )
+
+    # In linux, the dep_test_path may point to a symbolic link, we also need to copy real file
+    get_filename_component( dep_realpath "${dep_test_path}" REALPATH )
+    get_filename_component( dep_name "${dep_test_path}" NAME )
+    # message( STATUS "depName: ${dep_name}" )
+    # message( STATUS "depFullPath: ${dep_test_path}" )
+    # message( STATUS "dep_realpath: ${dep_realpath}" )
+
+    if( NOT EXISTS ${installPath}/${dep_name} )
+        file( INSTALL ${dep_test_path} ${dep_realpath}
+              USE_SOURCE_PERMISSIONS
+              DESTINATION ${installPath}
+            )
+    endif( )
+endforeach( )


### PR DESCRIPTION
Dynamically query dependencies on test executables and package those dependencies in addition to the test executables.  For debug builds, debug symbols and a snapshot of the code is also packaged.

Fixing the TravisCI build badge on the main readme.md file.
