### PR TITLE
Workaround for 2D FFT failures on NVIDIA GPUs

### DIFF
--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -1512,6 +1512,20 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					return	CLFFT_SUCCESS;
 				}
 
+                // TODO : Check for a better way to do this.
+                bool isnvidia = false;
+                for (size_t Idx = 0; !isnvidia && Idx < numQueues; Idx++)
+                {
+                    cl_command_queue QIdx = commQueueFFT[Idx];
+                    cl_device_id Device;
+                    clGetCommandQueueInfo(QIdx, CL_QUEUE_DEVICE, sizeof(Device), &Device, NULL);
+                    char Vendor[256];
+                    clGetDeviceInfo(Device, CL_DEVICE_VENDOR, sizeof(Vendor), &Vendor, NULL);
+                    isnvidia |= (strncmp(Vendor, "NVIDIA", 6) == 0);
+                }
+                // nvidia gpus are failing when doing transpose for 2D FFTs
+                if (isnvidia) break;
+
 				if (fftPlan->length.size() != 2) break;
 				if (!(IsPo2(fftPlan->length[0])) || !(IsPo2(fftPlan->length[1])))
 					break;


### PR DESCRIPTION
- Issue: https://github.com/clMathLibraries/clFFT/issues/25
- Inplace transpose were being used for power of 2 dimensions
- If device from NVIDIA, then alternative path is taken
