### PR TITLE
Add an option to control shared vs static library builds.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,7 @@ option( BUILD_RUNTIME "Build the FFT runtime library" ON )
 option( BUILD_CLIENT "Build a command line clFFT client program with a variety of configurable parameters (dependency on Boost)" ON )
 option( BUILD_TEST "Build the library testing suite (dependency on google test, Boost, and FFTW)" ON )
 option( BUILD_LOADLIBRARIES "Build the optional dynamic load libraries that the FFT runtime will search for" ON )
+option( BUILD_SHARED_LIBRARY "Build shared libraries." ON)
 
 # If BOOST_ROOT is defined as an environment value, use that value and cache it so it's visible in the cmake-gui.  
 # Otherwise, create a sensible default that the user can change

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -74,7 +74,11 @@ add_definitions( "/DCLFFT_EXPORTS" )
 # Include standard OpenCL headers
 include_directories( ${OPENCL_INCLUDE_DIRS} ${PROJECT_BINARY_DIR}/include ../include )
 
-add_library( clFFT SHARED ${clFFT.Files} )
+if(BUILD_SHARED_LIBRARY)
+  add_library( clFFT SHARED ${clFFT.Files} )
+else()
+  add_library( clFFT STATIC ${clFFT.Files} )
+endif()
 target_link_libraries( clFFT ${OPENCL_LIBRARIES} )
 
 set_target_properties( clFFT PROPERTIES VERSION ${CLFFT_VERSION} )

--- a/src/statTimer/CMakeLists.txt
+++ b/src/statTimer/CMakeLists.txt
@@ -63,7 +63,11 @@ add_definitions( "/DSTATTIMER_EXPORTS" )
 # Include standard OpenCL headers
 include_directories( ${OPENCL_INCLUDE_DIRS} ${PROJECT_BINARY_DIR}/include ../include )
 
-add_library( StatTimer SHARED ${StatTimer.Files} )
+if(BUILD_SHARED_LIBRARY)
+  add_library( StatTimer SHARED ${StatTimer.Files} )
+else()
+  add_library( StatTimer STATIC ${StatTimer.Files} )
+endif()
 set_target_properties( StatTimer PROPERTIES VERSION ${CLFFT_VERSION} )
 set_target_properties( StatTimer PROPERTIES SOVERSION ${CLFFT_SOVERSION} )
 set_target_properties( StatTimer PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )


### PR DESCRIPTION
This adds an option to the CMakeCache to facilitate building shared or static libaries. In the cmake gui this is exposed as a checkbox.
