### PR TITLE
On UNIX systems try to store kernels in tmp dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -228,6 +228,11 @@ if( MSVC AND UNICODE )
 	add_definitions( "/DUNICODE /D_UNICODE" )
 endif( )
 
+# If UNIX pass this to make use of POSIX specific API
+if( UNIX )
+    add_definitions( "-DHAVE_UNIX=1" )
+endif( )
+
 # Print out compiler flags for viewing/debug
 message( STATUS "CMAKE_CXX_COMPILER flags: " ${CMAKE_CXX_FLAGS} )
 message( STATUS "CMAKE_CXX_COMPILER debug flags: " ${CMAKE_CXX_FLAGS_DEBUG} )

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -18,8 +18,8 @@
 
 // clfft.plan.cpp : Defines the entry point for the console application.
 //
-
 #include "stdafx.h"
+#include <stdio.h>
 #include <math.h>
 #include "private.h"
 #include "repo.h"
@@ -208,6 +208,11 @@ clfftStatus WriteKernel( const clfftPlanHandle plHandle, const clfftGenerators g
 		case Stockham:		generatorName = "Stockham"; break;
 		case Transpose:		generatorName = "Transpose"; break;
 	}
+
+#ifdef HAVE_UNIX
+    // In case of UNIX-like systems prepend tmp dir path
+    kernelPath << P_tmpdir << "/";
+#endif
 
 	kernelPath << kernelPrefix << generatorName << plHandle << ".cl";
 


### PR DESCRIPTION
This change adds a new compiler definition HAVE_UNIX and uses P_tmpdir to store
the kernel files in a temporary location rather than the current working
directory.

There are two reasons why I think this would be a good addition: 1) it doesn't clutter my current working directory and 2) I cannot always write in my current working directory.