### PR TITLE
Install scripts/perf to share/clfft on non WIN32 systems

### DIFF
--- a/src/scripts/perf/CMakeLists.txt
+++ b/src/scripts/perf/CMakeLists.txt
@@ -20,5 +20,8 @@ set(GRAPHING_SCRIPTS 	measurePerformance.py
 						errorHandler.py 
 						performanceUtility.py
 						)
-
-install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )
+if( WIN32 )
+	install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )
+else ( )
+	install( FILES ${GRAPHING_SCRIPTS} DESTINATION share/clfft/${SUFFIX_BIN} )
+endif( )


### PR DESCRIPTION
I recently brought clfft to the Gentoo Linux scientific overlay. I had to patch the CMakeLists.txt for the scripts/perf subpackage, as the Python scripts get directly installed to /usr/bin otherwise. That's not a real good idea on Linux systems. Therefore, I propose to change the destination if the system isn't WIN32.