### PR TITLE
Install scripts/perf to share/clFFT on non WIN32 systems

### DIFF
--- a/src/scripts/perf/CMakeLists.txt
+++ b/src/scripts/perf/CMakeLists.txt
@@ -20,5 +20,8 @@ set(GRAPHING_SCRIPTS 	measurePerformance.py
 						errorHandler.py 
 						performanceUtility.py
 						)
-
-install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )
+if( WIN32 )
+	install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )
+else ( )
+	install( FILES ${GRAPHING_SCRIPTS} DESTINATION share/clFFT )
+endif( )


### PR DESCRIPTION
Here the new pull request with the changes discussed in request https://github.com/clMathLibraries/clFFT/pull/50. I further replaces `share/clfft` by `share/clFFT`.