### PR TITLE
Rename Client to clFFT-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 # Run a simple test to validate that the build works; CPU device in a VM
   - cd package/bin
   - export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/bin/clFFT/package/lib64:${LD_LIBRARY_PATH}
-  - ./Client -i
+  - ./clFFT-client -i
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR}/bin/clFFT

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -43,15 +43,15 @@ endif( )
 # Include standard OpenCL headers
 include_directories( ${Boost_INCLUDE_DIRS} ${OPENCL_INCLUDE_DIRS} ../../../common ${PROJECT_BINARY_DIR}/include ../include )
 
-add_executable( Client ${Client.Files} )
+add_executable( clFFT-client ${Client.Files} )
 
-target_link_libraries( Client clFFT ${Boost_LIBRARIES} ${OPENCL_LIBRARIES} ${DL_LIB} )
+target_link_libraries( clFFT-client clFFT ${Boost_LIBRARIES} ${OPENCL_LIBRARIES} ${DL_LIB} )
 
-set_target_properties( Client PROPERTIES VERSION ${CLFFT_VERSION} )
-set_target_properties( Client PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+set_target_properties( clFFT-client PROPERTIES VERSION ${CLFFT_VERSION} )
+set_target_properties( clFFT-client PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
 
 # CPack configuration; include the executable into the package
-install( TARGETS Client
+install( TARGETS clFFT-client
         RUNTIME DESTINATION bin${SUFFIX_BIN}
         LIBRARY DESTINATION lib${SUFFIX_LIB}
         ARCHIVE DESTINATION lib${SUFFIX_LIB}/import


### PR DESCRIPTION
The client executable gets installed as /usr/bin/Client on Linux Systems. I suggest to install it as clFFT-client.