### PR TITLE
rename the Client executable to a more something more specific to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 # Run a simple test to validate that the build works; CPU device in a VM
   - cd package/bin
   - export LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/bin/clFFT/package/lib64:${LD_LIBRARY_PATH}
-  - ./Client -i
+  - ./clfft -i
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR}/bin/clFFT

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable( Client ${Client.Files} )
 
 target_link_libraries( Client clFFT ${Boost_LIBRARIES} ${OPENCL_LIBRARIES} ${DL_LIB} )
 
+set_target_properties( Client PROPERTIES OUTPUT_NAME "clfft" )
 set_target_properties( Client PROPERTIES VERSION ${CLFFT_VERSION} )
 set_target_properties( Client PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
 


### PR DESCRIPTION
Client is a quite common and not a very descriptive name. It can conflict with
other program when installing in the usual place on unixes (/usr, /usr/local,
/opt).