### PR TITLE
use the default install prefix on unixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir -p bin/clFFT
   - cd bin/clFFT
-  - cmake -DBoost_NO_SYSTEM_PATHS=OFF ../../src
+  - cmake -DBoost_NO_SYSTEM_PATHS=OFF -DCMAKE_INSTALL_PREFIX:PATH=$PWD/package ../../src
 
 script: 
   - make install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,7 @@ set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR} )
 
 # On windows, it's convenient to change the default install prefix such that it does NOT point to 'program files'
 # Need to check out CMAKE_RUNTIME_OUTPUT_DIRECTORY variable, and see if that eliminates the need to modify install path
-if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+if( WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
 	set( CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/package" CACHE PATH "Install path prefix, prepended onto install directories" FORCE )
 endif( )
 


### PR DESCRIPTION
as documented, this option mainly make sense on windows. On unixes, it is
quite certainly not the expected behavior.