### PR TITLE
build google test with an external project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,10 @@ compiler:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq fglrx opencl-headers libboost-program-options-dev libfftw3-dev libgtest-dev
+  - sudo apt-get install -qq fglrx opencl-headers libboost-program-options-dev libfftw3-dev
 # Uncomment below to help verify the installs above work
 #  - ls -la /usr/lib/libboost*
 #  - ls -la /usr/include/boost
-#  - ls -la /usr/src/gtest
-
-install:
-  - mkdir -p bin/gTest
-  - cd bin/gTest
-  - cmake -DCMAKE_BUILD_TYPE=Release /usr/src/gtest
-  - make
-  - sudo mv libg* /usr/lib
 
 before_script:
   - cd ${TRAVIS_BUILD_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,17 +156,7 @@ find_package( OpenCL )
 # This will define FFTW_FOUND
 find_package( FFTW )
 
-if( (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_LESS 2.8) )
-	message( STATUS "Cmake version 2.8 or greater needed to use GTest" )
-else()
-	# This will define GTEST_FOUND
-	find_package( GTest )
-
-	# Hack to get googletest v1.6 to work with vs2012
-	if( MSVC11 )
-		add_definitions( "/D_VARIADIC_MAX=10" )
-	endif( )
-endif()
+include(gtest.cmake)
 
 # Enable building of the clACML client if both requested and all dependencies are found
 if( BUILD_CLIENT AND Boost_FOUND )

--- a/src/gtest.cmake
+++ b/src/gtest.cmake
@@ -1,0 +1,45 @@
+
+option(USE_SYSTEM_GTEST "Use system installed gtest when set to ON, or build gtest locally when set to OFF" OFF)
+
+if(USE_SYSTEM_GTEST)
+  if( (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_LESS 2.8) )
+    message( STATUS "Cmake version 2.8 or greater needed to use GTest" )
+  else()
+    # This will define GTEST_FOUND
+    find_package( GTest )
+  endif()
+else()
+#  find_package(Threads REQUIRED)
+  include(ExternalProject)
+
+  ExternalProject_Add(
+    gtest-external
+    URL http://googletest.googlecode.com/files/gtest-1.7.0.zip
+    URL_MD5 2d6ec8ccdf5c46b05ba54a9fd1d130d7
+    INSTALL_COMMAND "")
+  
+  ExternalProject_Get_Property(gtest-external binary_dir)
+  add_library(gtest IMPORTED STATIC GLOBAL)
+  set_target_properties(gtest PROPERTIES
+      IMPORTED_LOCATION ${binary_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}
+      # IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT}
+      )
+  add_dependencies(gtest gtest-external)
+
+  add_library(gtest_main IMPORTED STATIC GLOBAL)
+  set_target_properties(gtest_main PROPERTIES
+      IMPORTED_LOCATION ${binary_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}
+      # IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT}
+      )
+  add_dependencies(gtest_main gtest-external)
+
+  ExternalProject_Get_Property(gtest-external source_dir)
+  set(GTEST_INCLUDE_DIRS ${source_dir}/include)
+  set(GTEST_LIBRARIES gtest gtest_main)
+  set(GTEST_FOUND ON)
+endif()
+
+# Hack to get googletest v1.6 to work with vs2012
+if( MSVC11 )
+  add_definitions( "/D_VARIADIC_MAX=10" )
+endif( )


### PR DESCRIPTION
Google test is downloaded and built using cmake external project when
USE_SYSTEM_GTEST is set to OFF - the default. It can still be used from the
installed location when setting USE_SYSTEM_GTEST to ON.

The mac homebrew package manager does not provide any way to install google test
and advise to use it on a per project basis.