### PR TITLE
fix gtest build with msvc and ninja

### DIFF
--- a/src/gtest.cmake
+++ b/src/gtest.cmake
@@ -9,33 +9,57 @@ if(USE_SYSTEM_GTEST)
     find_package( GTest )
   endif()
 else()
-#  find_package(Threads REQUIRED)
+  if(CMAKE_VERSION VERSION_LESS 3.2 AND CMAKE_GENERATOR MATCHES "Ninja")
+    message(WARNING "Building GTest with Ninja has known issues with CMake older than 3.2")
+  endif()
+
   include(ExternalProject)
+
+  set(GTEST_LIBRARIES gtest gtest_main)
+  # the binary dir must be know before creating the external project in order
+  # to pass the byproducts
+  set(prefix "${CMAKE_CURRENT_BINARY_DIR}/gtest-external-prefix")
+  set(binary_dir "${prefix}/src/gtest-external-build")
+
+  set(byproducts)
+  foreach(lib ${GTEST_LIBRARIES})
+    set(${lib}_location
+      ${binary_dir}/${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    list(APPEND byproducts ${${lib}_location})
+  endforeach()
 
   ExternalProject_Add(
     gtest-external
     URL http://googletest.googlecode.com/files/gtest-1.7.0.zip
     URL_MD5 2d6ec8ccdf5c46b05ba54a9fd1d130d7
+    PREFIX ${prefix}
+    BINARY_DIR ${binary_dir}
+    CMAKE_CACHE_ARGS
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
+      -DCMAKE_CXX_FLAGS_DEBUG:STRING=${CMAKE_CXX_FLAGS_DEBUG}
+      -DCMAKE_CXX_FLAGS_MINSIZEREL:STRING=${CMAKE_CXX_FLAGS_MINSIZEREL}
+      -DCMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=${CMAKE_CXX_FLAGS_RELWITHDEBINFO}
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS}
+      -DCMAKE_C_FLAGS_DEBUG:STRING=${CMAKE_C_FLAGS_DEBUG}
+      -DCMAKE_C_FLAGS_MINSIZEREL:STRING=${CMAKE_C_FLAGS_MINSIZEREL}
+      -DCMAKE_C_FLAGS_RELEASE:STRING=${CMAKE_C_FLAGS_RELEASE}
+      -DCMAKE_C_FLAGS_RELWITHDEBINFO:STRING=${CMAKE_C_FLAGS_RELWITHDEBINFO}
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      -Dgtest_force_shared_crt:BOOL=ON
+    BUILD_BYPRODUCTS ${byproducts}
     INSTALL_COMMAND "")
-  
-  ExternalProject_Get_Property(gtest-external binary_dir)
-  add_library(gtest IMPORTED STATIC GLOBAL)
-  set_target_properties(gtest PROPERTIES
-      IMPORTED_LOCATION ${binary_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}
-      # IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT}
-      )
-  add_dependencies(gtest gtest-external)
 
-  add_library(gtest_main IMPORTED STATIC GLOBAL)
-  set_target_properties(gtest_main PROPERTIES
-      IMPORTED_LOCATION ${binary_dir}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}
-      # IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT}
-      )
-  add_dependencies(gtest_main gtest-external)
+  foreach(lib ${GTEST_LIBRARIES})
+    add_library(${lib} IMPORTED STATIC)
+    add_dependencies(${lib} gtest-external)
+    set_target_properties(${lib} PROPERTIES IMPORTED_LOCATION ${${lib}_location})
+  endforeach()
 
   ExternalProject_Get_Property(gtest-external source_dir)
   set(GTEST_INCLUDE_DIRS ${source_dir}/include)
-  set(GTEST_LIBRARIES gtest gtest_main)
   set(GTEST_FOUND ON)
 endif()
 


### PR DESCRIPTION
build with ninja only works properly with the very last cmake version.
A warning is displayed when ninja is used with a too old cmake version