### PR TITLE
Develop

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -844,7 +844,7 @@ int _tmain( int argc, _TCHAR* argv[] )
 			terr << _T("You have selected mutually-exclusive OpenCL device options:") << std::endl;
 			if (vm.count ( "gpu" )  > 0) terr << _T("    gpu,g   Force selection of OpenCL GPU devices only" ) << std::endl;
 			if (vm.count ( "cpu" )  > 0) terr << _T("    cpu,c   Force selection of OpenCL CPU devices only" ) << std::endl;
-			if (vm.count ( "all" )  > 0) terr << _T("    all,a   Force selection of all OpenCL devices" ) << std::endl;
+			if (vm.count ( "all" )  > 0) terr << _T("    all,a   Force selection of all OpenCL devices (default)" ) << std::endl;
 			return 1;
 		}
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -753,7 +753,6 @@ int _tmain( int argc, _TCHAR* argv[] )
 
 	//	OpenCL state
 	cl_device_type		deviceType	= CL_DEVICE_TYPE_DEFAULT;
-	cl_uint				deviceGpuList     = 0;	// a bitmap set
 	cl_int				deviceId = -1;
 
 	//	FFT state
@@ -788,7 +787,7 @@ int _tmain( int argc, _TCHAR* argv[] )
 			( "gpu,g",         "Force selection of OpenCL GPU devices only" )
 			( "cpu,c",         "Force selection of OpenCL CPU devices only" )
 			( "all,a",         "Force selection of all OpenCL devices" )
-			( "device",        po::value< cl_int >( &deviceId )->default_value( -1 ),   "Force selection of specific OpenCL device id as reported by clInfo" )
+			( "device",        po::value< cl_int >( &deviceId )->default_value( -1 ),   "Force selection of a specific OpenCL device id as it is reported by clInfo" )
 			( "outPlace,o",    "Out of place FFT transform (default: in place)" )
 			( "double",		   "Double precision transform (default: single)" )
 			( "inv",			"Backward transform (default: forward)" )
@@ -843,8 +842,8 @@ int _tmain( int argc, _TCHAR* argv[] )
 			| ((vm.count( "all" ) > 0) ? 4 : 0);
 		if ((mutex & (mutex-1)) != 0) {
 			terr << _T("You have selected mutually-exclusive OpenCL device options:") << std::endl;
-			if (vm.count ( "gpu" )  > 0) terr << _T("    gpu,g   Force selection of an OpenCL GPU devices only" ) << std::endl;
-			if (vm.count ( "cpu" )  > 0) terr << _T("    cpu,c   Force selection of an OpenCL CPU devices only" ) << std::endl;
+			if (vm.count ( "gpu" )  > 0) terr << _T("    gpu,g   Force selection of OpenCL GPU devices only" ) << std::endl;
+			if (vm.count ( "cpu" )  > 0) terr << _T("    cpu,c   Force selection of OpenCL CPU devices only" ) << std::endl;
 			if (vm.count ( "all" )  > 0) terr << _T("    all,a   Force selection of all OpenCL devices" ) << std::endl;
 			return 1;
 		}
@@ -852,7 +851,6 @@ int _tmain( int argc, _TCHAR* argv[] )
 		if( vm.count( "gpu" ) )
 		{
 			deviceType	= CL_DEVICE_TYPE_GPU;
-			deviceGpuList = ~0;
 		}
 
 		if( vm.count( "cpu" ) )

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -47,7 +47,7 @@ template < typename T >
 int transform( size_t* lengths, const size_t *inStrides, const size_t *outStrides, size_t batch_size,
 				clfftLayout in_layout, clfftLayout out_layout,
 				clfftResultLocation place, clfftPrecision precision, clfftDirection dir,
-				cl_device_type deviceType, cl_uint deviceGpuList, bool printInfo,
+				cl_device_type deviceType, cl_int deviceId, bool printInfo,
 				cl_uint command_queue_flags, cl_uint profile_count,
 				std::auto_ptr< clfftSetupData > setupData )
 {
@@ -168,7 +168,7 @@ int transform( size_t* lengths, const size_t *inStrides, const size_t *outStride
 			//	This call creates our openCL context and sets up our devices; expected to throw on error
 			size_of_input_buffers_in_bytes = fftBatchSize * sizeof( std::complex< T > );
 
-			device_id = initializeCL( deviceType, deviceGpuList, context, printInfo );
+			device_id = initializeCL( deviceType, deviceId, context, printInfo );
 			createOpenCLCommandQueue( context,
 				command_queue_flags, queue,
 				device_id,
@@ -214,7 +214,7 @@ int transform( size_t* lengths, const size_t *inStrides, const size_t *outStride
 			//	This call creates our openCL context and sets up our devices; expected to throw on error
 			size_of_input_buffers_in_bytes = fftBatchSize * sizeof( T );
 
-			device_id = initializeCL( deviceType, deviceGpuList, context, printInfo );
+			device_id = initializeCL( deviceType, deviceId, context, printInfo );
 			createOpenCLCommandQueue( context,
 				command_queue_flags, queue,
 				device_id,
@@ -264,7 +264,7 @@ int transform( size_t* lengths, const size_t *inStrides, const size_t *outStride
 			//	This call creates our openCL context and sets up our devices; expected to throw on error
 			size_of_input_buffers_in_bytes = fftBatchSize * sizeof( std::complex< T > );
 
-			device_id = initializeCL( deviceType, deviceGpuList, context, printInfo );
+			device_id = initializeCL( deviceType, deviceId, context, printInfo );
 			createOpenCLCommandQueue( context,
 				command_queue_flags, queue,
 				device_id,
@@ -298,7 +298,7 @@ int transform( size_t* lengths, const size_t *inStrides, const size_t *outStride
 			//	This call creates our openCL context and sets up our devices; expected to throw on error
 			size_of_input_buffers_in_bytes = fftBatchSize * sizeof( T );
 
-			device_id = initializeCL( deviceType, deviceGpuList, context, printInfo );
+			device_id = initializeCL( deviceType, deviceId, context, printInfo );
 			createOpenCLCommandQueue( context,
 				command_queue_flags, queue,
 				device_id,
@@ -337,7 +337,7 @@ int transform( size_t* lengths, const size_t *inStrides, const size_t *outStride
 			//	This call creates our openCL context and sets up our devices; expected to throw on error
 			size_of_input_buffers_in_bytes = fftBatchSize * sizeof( T );
 
-			device_id = initializeCL( deviceType, deviceGpuList, context, printInfo );
+			device_id = initializeCL( deviceType, deviceId, context, printInfo );
 			createOpenCLCommandQueue( context,
 				command_queue_flags, queue,
 				device_id,
@@ -754,6 +754,7 @@ int _tmain( int argc, _TCHAR* argv[] )
 	//	OpenCL state
 	cl_device_type		deviceType	= CL_DEVICE_TYPE_DEFAULT;
 	cl_uint				deviceGpuList     = 0;	// a bitmap set
+	cl_int				deviceId = -1;
 
 	//	FFT state
 
@@ -784,9 +785,10 @@ int _tmain( int argc, _TCHAR* argv[] )
 			( "help,h",        "produces this help message" )
 			( "version,v",     "Print queryable version information from the clFFT library" )
 			( "clInfo,i",      "Print queryable information of the OpenCL runtime" )
-			( "gpu,g",         "Force instantiation of an OpenCL GPU device" )
-			( "cpu,c",         "Force instantiation of an OpenCL CPU device" )
-			( "all,a",         "Force instantiation of all OpenCL devices" )
+			( "gpu,g",         "Force selection of OpenCL GPU devices only" )
+			( "cpu,c",         "Force selection of OpenCL CPU devices only" )
+			( "all,a",         "Force selection of all OpenCL devices" )
+			( "device",        po::value< cl_int >( &deviceId )->default_value( -1 ),   "Force selection of specific OpenCL device id as reported by clInfo" )
 			( "outPlace,o",    "Out of place FFT transform (default: in place)" )
 			( "double",		   "Double precision transform (default: single)" )
 			( "inv",			"Backward transform (default: forward)" )
@@ -841,9 +843,9 @@ int _tmain( int argc, _TCHAR* argv[] )
 			| ((vm.count( "all" ) > 0) ? 4 : 0);
 		if ((mutex & (mutex-1)) != 0) {
 			terr << _T("You have selected mutually-exclusive OpenCL device options:") << std::endl;
-			if (vm.count ( "gpu" )  > 0) terr << _T("    gpu,g   Force instantiation of an OpenCL GPU device" ) << std::endl;
-			if (vm.count ( "cpu" )  > 0) terr << _T("    cpu,c   Force instantiation of an OpenCL CPU device" ) << std::endl;
-			if (vm.count ( "all" )  > 0) terr << _T("    all,a   Force instantiation of all OpenCL devices" ) << std::endl;
+			if (vm.count ( "gpu" )  > 0) terr << _T("    gpu,g   Force selection of an OpenCL GPU devices only" ) << std::endl;
+			if (vm.count ( "cpu" )  > 0) terr << _T("    cpu,c   Force selection of an OpenCL CPU devices only" ) << std::endl;
+			if (vm.count ( "all" )  > 0) terr << _T("    all,a   Force selection of all OpenCL devices" ) << std::endl;
 			return 1;
 		}
 
@@ -972,9 +974,9 @@ int _tmain( int argc, _TCHAR* argv[] )
 		}
 
 		if( precision == CLFFT_SINGLE )
-			transform<float>( lengths, iStrides, oStrides, batchSize, inLayout, outLayout, place, precision, dir, deviceType, deviceGpuList, printInfo, command_queue_flags, profile_count, setupData );
+			transform<float>( lengths, iStrides, oStrides, batchSize, inLayout, outLayout, place, precision, dir, deviceType, deviceId, printInfo, command_queue_flags, profile_count, setupData );
 		else
-			transform<double>( lengths, iStrides, oStrides, batchSize, inLayout, outLayout, place, precision, dir, deviceType, deviceGpuList, printInfo, command_queue_flags, profile_count, setupData );
+			transform<double>( lengths, iStrides, oStrides, batchSize, inLayout, outLayout, place, precision, dir, deviceType, deviceId, printInfo, command_queue_flags, profile_count, setupData );
 	}
 	catch( std::exception& e )
 	{

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -751,7 +751,7 @@ int _tmain( int argc, _TCHAR* argv[] )
 
 #endif /* MEMORYREPORT */
 
-	//	OpenCL state
+	//	OpenCL state 
 	cl_device_type		deviceType	= CL_DEVICE_TYPE_ALL;
 	cl_int				deviceId = -1;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -752,7 +752,7 @@ int _tmain( int argc, _TCHAR* argv[] )
 #endif /* MEMORYREPORT */
 
 	//	OpenCL state
-	cl_device_type		deviceType	= CL_DEVICE_TYPE_DEFAULT;
+	cl_device_type		deviceType	= CL_DEVICE_TYPE_ALL;
 	cl_int				deviceId = -1;
 
 	//	FFT state
@@ -786,7 +786,7 @@ int _tmain( int argc, _TCHAR* argv[] )
 			( "clInfo,i",      "Print queryable information of the OpenCL runtime" )
 			( "gpu,g",         "Force selection of OpenCL GPU devices only" )
 			( "cpu,c",         "Force selection of OpenCL CPU devices only" )
-			( "all,a",         "Force selection of all OpenCL devices" )
+			( "all,a",         "Force selection of all OpenCL devices (default)" )
 			( "device",        po::value< cl_int >( &deviceId )->default_value( -1 ),   "Force selection of a specific OpenCL device id as it is reported by clInfo" )
 			( "outPlace,o",    "Out of place FFT transform (default: in place)" )
 			( "double",		   "Double precision transform (default: single)" )

--- a/src/client/openCL.misc.cpp
+++ b/src/client/openCL.misc.cpp
@@ -393,7 +393,7 @@ int discoverCLPlatforms( cl_device_type deviceType,
 				"Getting OpenCL devices ( ::clGetDeviceIDs() )");
 			if (0 == numDevices)
 			{
-				OPENCL_V_WARN(CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
+				// OPENCL_V_WARN(CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
 				continue;
 			}
 

--- a/src/client/openCL.misc.cpp
+++ b/src/client/openCL.misc.cpp
@@ -459,15 +459,15 @@ std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
 	}
 
 	// Do some error checking if we really selected a valid platform and a valid device
+	if (NULL == devices[0])
+	{
+		OPENCL_V_THROW(CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
+	}
+
 	if (NULL == platform)
 	{
 		throw std::runtime_error("No appropriate OpenCL platform could be found");
-	}
-
-	if (NULL == devices[0])
-	{
-		OPENCL_V_THROW( CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
-	}
+	}	
 		
 	// Create an OpenCL context
 	cl_context_properties cps[3] = { CL_CONTEXT_PLATFORM, (cl_context_properties) platform, 0 };

--- a/src/client/openCL.misc.cpp
+++ b/src/client/openCL.misc.cpp
@@ -24,7 +24,6 @@
 #include <sstream>
 #include <cstring>
 #include <vector>
-#include <map>
 #include "clFFT.h"
 #include "openCL.misc.h"
 
@@ -215,7 +214,7 @@ void prettyPrintDeviceInfo( const cl_device_id& dId )
 void prettyPrintCLPlatforms(std::vector< cl_platform_id >& platforms,
 	std::vector< std::vector< cl_device_id > >& devices)
 {
-	unsigned int devNr = 0;
+	unsigned int devNo = 0;
 	
 	for (unsigned int i = 0; i < platforms.size(); ++i)
 	{
@@ -224,9 +223,9 @@ void prettyPrintCLPlatforms(std::vector< cl_platform_id >& platforms,
 
 		for (unsigned int n = 0; n < devices[i].size(); ++n)
 		{
-			std::cout << "OpenCL device [ " << devNr << " ]:" << std::endl;
+			std::cout << "OpenCL platform [ " << i << " ], device [ " << devNo << " ]:" << std::endl;
 			prettyPrintDeviceInfo((devices[i])[n]);
-			devNr++;
+			devNo++;
 		}
 	}
 
@@ -417,10 +416,7 @@ std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
 	std::vector< cl_device_id > devices(1);
 	devices[0] = NULL;
 	
-	/*
-	* Have a look at the available platforms and pick either
-	* the AMD one if available or a reasonable default.
-	*/
+	// Have a look at all the available platforms on this system
 	std::vector< cl_platform_id > platformInfos;
 	std::vector< std::vector< cl_device_id > > deviceInfos;
 	discoverCLPlatforms( deviceType, platformInfos, deviceInfos );
@@ -462,6 +458,7 @@ std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
 		}
 	}
 
+	// Do some error checking if we really selected a valid platform and a valid device
 	if (NULL == platform)
 	{
 		throw std::runtime_error("No appropriate OpenCL platform could be found");
@@ -471,11 +468,8 @@ std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
 	{
 		OPENCL_V_THROW( CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
 	}
-	
 		
-	/////////////////////////////////////////////////////////////////
 	// Create an OpenCL context
-	/////////////////////////////////////////////////////////////////
 	cl_context_properties cps[3] = { CL_CONTEXT_PLATFORM, (cl_context_properties) platform, 0 };
 	context = clCreateContext(cps,
 		(cl_uint)devices.size(),

--- a/src/client/openCL.misc.h
+++ b/src/client/openCL.misc.h
@@ -29,6 +29,15 @@
 	#define countOf( arr ) ( sizeof( arr ) / sizeof( arr[ 0 ] ) )
 #endif
 
+class ClPlatformDiscoverer
+{
+	std::vector< cl_platform_id > mPlatforms;
+	std::vector< std::vector< cl_device_id > > devices;
+
+public:
+
+};
+
 /*
  * \brief OpenCL related initialization
  *        Create Context, Device list
@@ -101,6 +110,7 @@ inline cl_int OpenCL_V_Throw ( cl_int res, const std::string& msg, size_t lineno
 	return	res;
 }
 #define OPENCL_V_THROW(_status,_message) OpenCL_V_Throw (_status, _message, __LINE__)
+#define OPENCL_V_WARN(_status,_message) std::cout << "Warning: " << _message << std::endl;
 
 /*
  * \brief Release OpenCL resources (Context, Memory etc.)

--- a/src/client/openCL.misc.h
+++ b/src/client/openCL.misc.h
@@ -117,6 +117,10 @@ inline cl_int OpenCL_V_Warn(cl_int res, const std::string& msg, size_t lineno)
 	{
 		case	CL_SUCCESS:		/**< No error */
 			break;
+		case	CL_DEVICE_NOT_FOUND:
+			// This happens all the time when discovering the OpenCL capabilities of the system,
+			// so do nothing here.
+			break;
 		default:
 		{
 			std::stringstream tmp;

--- a/src/client/openCL.misc.h
+++ b/src/client/openCL.misc.h
@@ -29,14 +29,14 @@
 	#define countOf( arr ) ( sizeof( arr ) / sizeof( arr[ 0 ] ) )
 #endif
 
-class ClPlatformDiscoverer
-{
-	std::vector< cl_platform_id > mPlatforms;
-	std::vector< std::vector< cl_device_id > > devices;
-
-public:
-
-};
+/*
+ * \brief OpenCL platform and device discovery
+ *        Creates a list of OpenCL platforms
+ *        and their associated devices 
+ */
+int discoverCLPlatforms( cl_device_type deviceType,
+					     std::vector< cl_platform_id >& platforms,
+						 std::vector< std::vector< cl_device_id > >& devices );
 
 /*
  * \brief OpenCL related initialization
@@ -45,7 +45,7 @@ public:
  *		  Build program and kernel objects
  */
 std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
-										  cl_uint deviceGpuList,
+										  cl_int deviceId,
 										  cl_context& context,
 										  bool printclInfo );
 
@@ -110,7 +110,30 @@ inline cl_int OpenCL_V_Throw ( cl_int res, const std::string& msg, size_t lineno
 	return	res;
 }
 #define OPENCL_V_THROW(_status,_message) OpenCL_V_Throw (_status, _message, __LINE__)
-#define OPENCL_V_WARN(_status,_message) std::cout << "Warning: " << _message << std::endl;
+
+inline cl_int OpenCL_V_Warn(cl_int res, const std::string& msg, size_t lineno)
+{
+	switch (res)
+	{
+		case	CL_SUCCESS:		/**< No error */
+			break;
+		default:
+		{
+			std::stringstream tmp;
+			tmp << "OPENCL_V_WARN< ";
+			tmp << prettyPrintclFFTStatus(res);
+			tmp << " > (";
+			tmp << lineno;
+			tmp << "): ";
+			tmp << msg;
+			std::string errorm(tmp.str());
+			std::cout << errorm << std::endl;
+		}
+	}
+
+	return	res;
+}
+#define OPENCL_V_WARN(_status,_message) OpenCL_V_Warn (_status, _message, __LINE__);
 
 /*
  * \brief Release OpenCL resources (Context, Memory etc.)

--- a/src/tests/cl_transform.h
+++ b/src/tests/cl_transform.h
@@ -264,7 +264,7 @@ public:
 			cl_context tempContext = NULL;
 			device_id = initializeCL(
 				device_type,
-				device_gpu_list,
+				dev_id,
 				tempContext,
 				printInfo
 			);

--- a/src/tests/gtest_main.cpp
+++ b/src/tests/gtest_main.cpp
@@ -59,7 +59,7 @@ bool suppress_output = false;
 //	Globals that user can set on the command line, that need to be passed down to unit tests
 cl_device_type device_type = CL_DEVICE_TYPE_GPU;
 cl_uint device_gpu_list = ~0x0;
-cl_int devId = -1;
+cl_int dev_id = -1;
 
 bool comparison_type = root_mean_square;
 
@@ -106,7 +106,7 @@ int main( int argc, char **argv )
 		( "noInfoCL",      "Don't print information from the OpenCL runtime" )
 		( "cpu,c",         "Run tests on a CPU device" )
 		( "gpu,g",         "Run tests on a GPU device (default)" )
-		( "device", po::value< cl_int >(&devId)->default_value(-1), "Run tests on a specific OpenCL device id as reported by clInfo")
+		("device", po::value< cl_int >(&dev_id)->default_value(-1), "Run tests on a specific OpenCL device id as reported by clInfo")
 		( "pointwise,p",         "Do a pointwise comparison to determine test correctness (default: use root mean square)" )
 		( "tolerance,t",        po::value< float >( &tolerance )->default_value( 0.001f ),   "tolerance level to use when determining test pass/fail" )
 		( "numRandom,r",        po::value< size_t >( &number_of_random_tests )->default_value( 2000 ),   "number of random tests to run" )
@@ -171,7 +171,7 @@ int main( int argc, char **argv )
 		cl_context tempContext = NULL;
 		cl_command_queue tempQueue = NULL;
 		cl_event tempEvent = NULL;
-		std::vector< cl_device_id > device_id = ::initializeCL( device_type, devId, tempContext, true );
+		std::vector< cl_device_id > device_id = ::initializeCL(device_type, dev_id, tempContext, true);
 		::cleanupCL( &tempContext, &tempQueue, 0, NULL, 0, NULL, &tempEvent );
 	}
 

--- a/src/tests/gtest_main.cpp
+++ b/src/tests/gtest_main.cpp
@@ -59,6 +59,8 @@ bool suppress_output = false;
 //	Globals that user can set on the command line, that need to be passed down to unit tests
 cl_device_type device_type = CL_DEVICE_TYPE_GPU;
 cl_uint device_gpu_list = ~0x0;
+cl_int devId = -1;
+
 bool comparison_type = root_mean_square;
 
 int main( int argc, char **argv )
@@ -104,6 +106,7 @@ int main( int argc, char **argv )
 		( "noInfoCL",      "Don't print information from the OpenCL runtime" )
 		( "cpu,c",         "Run tests on a CPU device" )
 		( "gpu,g",         "Run tests on a GPU device (default)" )
+		( "device", po::value< cl_int >(&devId)->default_value(-1), "Run tests on a specific OpenCL device id as reported by clInfo")
 		( "pointwise,p",         "Do a pointwise comparison to determine test correctness (default: use root mean square)" )
 		( "tolerance,t",        po::value< float >( &tolerance )->default_value( 0.001f ),   "tolerance level to use when determining test pass/fail" )
 		( "numRandom,r",        po::value< size_t >( &number_of_random_tests )->default_value( 2000 ),   "number of random tests to run" )
@@ -168,7 +171,7 @@ int main( int argc, char **argv )
 		cl_context tempContext = NULL;
 		cl_command_queue tempQueue = NULL;
 		cl_event tempEvent = NULL;
-		std::vector< cl_device_id > device_id = ::initializeCL( device_type, device_gpu_list, tempContext, true );
+		std::vector< cl_device_id > device_id = ::initializeCL( device_type, devId, tempContext, true );
 		::cleanupCL( &tempContext, &tempQueue, 0, NULL, 0, NULL, &tempEvent );
 	}
 

--- a/src/tests/test_constants.cpp
+++ b/src/tests/test_constants.cpp
@@ -88,7 +88,7 @@ size_t max_mem_available_on_cl_device(size_t device_index) {
 	cl_context tempContext = NULL;
 	device_id = initializeCL(
 		device_type,
-		device_gpu_list,
+		dev_id,
 		tempContext,
 		false
 		);

--- a/src/tests/test_constants.h
+++ b/src/tests/test_constants.h
@@ -63,6 +63,7 @@ extern float tolerance;
 
 extern cl_device_type device_type;
 extern cl_uint device_gpu_list;
+extern cl_int dev_id;
 
 extern size_t number_of_random_tests;
 extern time_t random_test_parameter_seed;

--- a/src/tests/unit_test.cpp
+++ b/src/tests/unit_test.cpp
@@ -29,12 +29,12 @@ protected:
 		lengths[ 0 ] = 32;
 		lengths[ 1 ] = 32;
 		lengths[ 2 ] = 32;
-		cl_uint	deviceGpuList = ~0; // a bitmap set
+		cl_int devId = -1;
 		commandQueueFlags = 0;
 
 		size_t memSizeBytes = lengths[ 0 ] * lengths[ 1 ] * lengths[ 2 ] * sizeof( std::complex< float > );
 
-		device_id = initializeCL( CL_DEVICE_TYPE_CPU, deviceGpuList, context, printInfo );
+		device_id = initializeCL( CL_DEVICE_TYPE_CPU, devId, context, printInfo );
 		createOpenCLCommandQueue( context,
 								  commandQueueFlags,
 								  queue,


### PR DESCRIPTION
In our environment we got several GPU and CPU devices in our system in parallel and should profile them indepedently for FFT performance. clfft-client for now only uses the last reported OpenCL device in a given category as a default. 

So this pull request is a patch that allows all OpenCL devices in a system to be enumerated (results printed out via "-i") and selected with their id in clfft-client. Selection is possible via a new command-line parameter "--device [dev-id]". Without the parameter clfft-client defaults to its current behaviour, selecting the last reported OpenCL device.

Afaik, this pull would also be a fix for issue #20.

It's just an idea and sort a "best-guess" implementation, but maybe it's of some use for the lib.
  