### PR TITLE
clfft-client - added a feature to select specific devices 

### DIFF
--- a/src/client/openCL.misc.cpp
+++ b/src/client/openCL.misc.cpp
@@ -27,6 +27,8 @@
 #include "clFFT.h"
 #include "openCL.misc.h"
 
+
+
 void prettyPrintPlatformInfo( const cl_platform_id& pId )
 {
 	size_t platformProfileSize	= 0;
@@ -209,6 +211,26 @@ void prettyPrintDeviceInfo( const cl_device_id& dId )
 	std::cout << std::right << std::endl;
 }
 
+void prettyPrintCLPlatforms(std::vector< cl_platform_id >& platforms,
+	std::vector< std::vector< cl_device_id > >& devices)
+{
+	unsigned int devNo = 0;
+	
+	for (unsigned int i = 0; i < platforms.size(); ++i)
+	{
+		std::cout << "OpenCL platform [ " << i << " ]:" << std::endl;
+		prettyPrintPlatformInfo(platforms[i]);
+
+		for (unsigned int n = 0; n < devices[i].size(); ++n)
+		{
+			std::cout << "OpenCL platform [ " << i << " ], device [ " << devNo << " ]:" << std::endl;
+			prettyPrintDeviceInfo((devices[i])[n]);
+			devNo++;
+		}
+	}
+
+}
+
 //	Verify a failed condition; return true on fail
 inline cl_bool OPENCL_V_FAIL( cl_int res )
 {
@@ -332,143 +354,129 @@ std::string prettyPrintclFFTStatus( const cl_int& status )
 	}
 }
 
-std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
-										  cl_uint deviceGpuList,
-										  cl_context& context,
-										  bool printclInfo )
+int discoverCLPlatforms( cl_device_type deviceType,
+						 std::vector< cl_platform_id >& platforms,
+						 std::vector< std::vector< cl_device_id > >& devices )
 {
 	cl_int status = 0;
 
 	/*
-		* Have a look at the available platforms and pick either
-		* the AMD one if available or a reasonable default.
-		*/
+	* Find all OpenCL platforms this system has to offer.
+	*/
 
-	cl_uint numPlatforms	= 0;
+	cl_uint numPlatforms = 0;
 	cl_platform_id platform = NULL;
-	OPENCL_V_THROW( ::clGetPlatformIDs( 0, NULL, &numPlatforms ),
-			"Getting number of platforms( ::clGetPlatformsIDs() )" );
+	OPENCL_V_THROW(::clGetPlatformIDs(0, NULL, &numPlatforms),
+		"Getting number of platforms( ::clGetPlatformsIDs() )");
 
-	if( numPlatforms > 0 )
+	if (numPlatforms > 0)
 	{
-		std::vector< cl_platform_id > platforms( numPlatforms );
-		OPENCL_V_THROW( ::clGetPlatformIDs( numPlatforms, &platforms[ 0 ], NULL ),
-			"Getting Platform Id's ( ::clGetPlatformsIDs() )" );
+		platforms.resize( numPlatforms );
+		devices.resize( numPlatforms );
+		OPENCL_V_THROW(::clGetPlatformIDs(numPlatforms, &platforms[0], NULL),
+			"Getting Platform Id's ( ::clGetPlatformsIDs() )");
 
-		//	TODO: How should we determine what platform to choose?  We are just defaulting to the last one reported, as we
-		//	print out the info
-		for( unsigned int i=0; i < numPlatforms; ++i )
+		if (NULL == platforms[0])
 		{
-			if( printclInfo )
+			throw std::runtime_error("No appropriate OpenCL platform could be found");
+		}
+		
+		/*
+		* Now, for each platform get all available devices matching deviceType.
+		*/
+		for (unsigned int i = 0; i < numPlatforms; ++i)
+		{
+			//	Get the device list for deviceType.
+			//
+			cl_uint numDevices = 0;
+			OPENCL_V_WARN(::clGetDeviceIDs(platforms[i], deviceType, 0, NULL, &numDevices),
+				"Getting OpenCL devices ( ::clGetDeviceIDs() )");
+			if (0 == numDevices)
 			{
-				std::cout << "OpenCL platform [ " << i << " ]:" << std::endl;
-				prettyPrintPlatformInfo( platforms[i] );
+				// OPENCL_V_WARN(CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
+				continue;
 			}
 
-			platform = platforms[i];
+			devices[i].resize(numDevices);
+			OPENCL_V_THROW(::clGetDeviceIDs(platforms[i], deviceType, numDevices, &(devices[i])[0], NULL),
+				"Getting OpenCL deviceIDs ( ::clGetDeviceIDs() )");
 		}
 	}
 
-	if( NULL == platform )
+	return 0;
+}
+
+std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
+										  cl_int deviceId,
+										  cl_context& context,
+										  bool printclInfo )
+{
+	cl_int status = 0;
+	cl_platform_id platform = NULL;
+	std::vector< cl_device_id > devices(1);
+	devices[0] = NULL;
+	
+	// Have a look at all the available platforms on this system
+	std::vector< cl_platform_id > platformInfos;
+	std::vector< std::vector< cl_device_id > > deviceInfos;
+	discoverCLPlatforms( deviceType, platformInfos, deviceInfos );
+	if (printclInfo)
 	{
-		throw std::runtime_error( "No appropriate OpenCL platform could be found" );
+		prettyPrintCLPlatforms(platformInfos, deviceInfos);
 	}
 
-	/*
-	 * If we could find our platform, use it. Otherwise use just available platform.
-	 */
-
-	//	Get the device list for this type.
-	//
-	cl_uint num_devices = 0;
-	OPENCL_V_THROW( ::clGetDeviceIDs( platform, deviceType, 0, NULL, &num_devices ),
-		"Getting OpenCL devices ( ::clGetDeviceIDs() )" );
-	if( 0 == num_devices )
+	if (deviceId >= 0)
 	{
-		OPENCL_V_THROW( CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
-	}
+		cl_int devNr = 0;
 
-	std::vector< cl_device_id > deviceIDs( num_devices );
-	OPENCL_V_THROW( ::clGetDeviceIDs( platform, deviceType, num_devices, &deviceIDs[0], NULL),
-		"Getting OpenCL deviceIDs ( ::clGetDeviceIDs() )" );
-
-	if( (CL_DEVICE_TYPE_GPU == deviceType) && (~cl_uint(0) != deviceGpuList) )
-	{
-		//	The command line options specify to user certain gpu(s)
-		//
-		for( unsigned u = (unsigned) deviceIDs.size(); u-- > 0; )
+		// A specific deviceId is selected, so try to find it
+		for (unsigned int i = 0; i < platformInfos.size(); ++i)
 		{
-			if( 0 != (deviceGpuList & (1<<u) ) )
-				continue;
+			for (unsigned int n = 0; n < deviceInfos[i].size(); ++n)
+			{
+				if (deviceId == devNr)
+				{
+					platform = platformInfos[i];
+					devices[0] = deviceInfos[i][n];
+				}
 
-			//  Remove this GPU from the list
-			deviceIDs[u] = deviceIDs.back();
-			deviceIDs.pop_back();
+				devNr++;
+			}
+		}
+	}
+	else
+	{
+		// The default device (here: the last reported device) shall be selected
+		for (unsigned int i = 0; i < platformInfos.size(); ++i)
+		{
+			for (unsigned int n = 0; n < deviceInfos[i].size(); ++n)
+			{
+				platform = platformInfos[i];
+				devices[0] = deviceInfos[i][n];
+			}
 		}
 	}
 
-	if( 0 == deviceIDs.size( ) )
+	// Do some error checking if we really selected a valid platform and a valid device
+	if (NULL == devices[0])
 	{
-		OPENCL_V_THROW( CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
+		OPENCL_V_THROW(CLFFT_DEVICE_NOT_AVAILABLE, "No devices available");
 	}
 
-	cl_context_properties cps[3] = { CL_CONTEXT_PLATFORM, (cl_context_properties)platform, 0 };
-
-	/////////////////////////////////////////////////////////////////
+	if (NULL == platform)
+	{
+		throw std::runtime_error("No appropriate OpenCL platform could be found");
+	}	
+		
 	// Create an OpenCL context
-	/////////////////////////////////////////////////////////////////
-	context = clCreateContext( cps,
-							   (cl_uint) deviceIDs.size(),
-							   & deviceIDs[0],
-							   NULL,
-							   NULL,
-							   &status);
-	OPENCL_V_THROW( status, "Creating Context ( ::clCreateContextFromType() )" );
-
-	/* First, get the size of device list data */
-	size_t deviceListSize;
-	OPENCL_V_THROW( ::clGetContextInfo( context, CL_CONTEXT_DEVICES, 0, NULL, &deviceListSize ),
-		"Getting device array size ( ::clGetContextInfo() )" );
-
-	/////////////////////////////////////////////////////////////////
-	// Detect OpenCL devices
-	/////////////////////////////////////////////////////////////////
-	std::vector< cl_device_id > devices( deviceListSize/sizeof( cl_device_id ) );
-
-	/* Now, get the device list data */
-	OPENCL_V_THROW( ::clGetContextInfo( context, CL_CONTEXT_DEVICES, deviceListSize, &devices[ 0 ], NULL ),
-		"Getting device array ( ::clGetContextInfo() )" );
-
-	if( printclInfo )
-	{
-		cl_uint cContextDevices	= 0;
-
-		size_t deviceVersionSize	= 0;
-		OPENCL_V_THROW( ::clGetDeviceInfo( devices[0], CL_DEVICE_VERSION, 0, NULL, &deviceVersionSize ),
-			"Getting CL_DEVICE_VERSION Platform Info string size ( ::clGetDeviceInfo() )" );
-
-		std::vector< char > szDeviceVersion( deviceVersionSize );
-		OPENCL_V_THROW( ::clGetDeviceInfo( devices[0], CL_DEVICE_VERSION, deviceVersionSize, &szDeviceVersion[ 0 ], NULL ),
-			"Getting CL_DEVICE_VERSION Platform Info string ( ::clGetDeviceInfo() )" );
-
-		char openclstr[11]="OpenCL 1.0";
-
-		if (!strncmp((const char*)&szDeviceVersion[ 0 ], openclstr, 10))
-		{
-			cContextDevices	= 1;
-		}
-		else
-		{
-			OPENCL_V_THROW( ::clGetContextInfo( context, CL_CONTEXT_NUM_DEVICES, sizeof( cContextDevices ), &cContextDevices, NULL ),
-				"Getting number of context devices ( ::clGetContextInfo() )" );
-		}
-
-		for( cl_uint i = 0; i < cContextDevices; ++i )
-		{
-			std::cout << "OpenCL devices [ " << i << " ]:" << std::endl;
-			prettyPrintDeviceInfo( devices[i] );
-		}
-	}
+	cl_context_properties cps[3] = { CL_CONTEXT_PLATFORM, (cl_context_properties) platform, 0 };
+	context = clCreateContext(cps,
+		(cl_uint)devices.size(),
+		&devices[0],
+		NULL,
+		NULL,
+		&status);
+	OPENCL_V_THROW(status, "Creating Context ( ::clCreateContextFromType() )");
 
 	return devices;
 }

--- a/src/client/openCL.misc.h
+++ b/src/client/openCL.misc.h
@@ -30,13 +30,22 @@
 #endif
 
 /*
+ * \brief OpenCL platform and device discovery
+ *        Creates a list of OpenCL platforms
+ *        and their associated devices 
+ */
+int discoverCLPlatforms( cl_device_type deviceType,
+					     std::vector< cl_platform_id >& platforms,
+						 std::vector< std::vector< cl_device_id > >& devices );
+
+/*
  * \brief OpenCL related initialization
  *        Create Context, Device list
  *        Load CL file, compile, link CL source
  *		  Build program and kernel objects
  */
 std::vector< cl_device_id > initializeCL( cl_device_type deviceType,
-										  cl_uint deviceGpuList,
+										  cl_int deviceId,
 										  cl_context& context,
 										  bool printclInfo );
 
@@ -101,6 +110,34 @@ inline cl_int OpenCL_V_Throw ( cl_int res, const std::string& msg, size_t lineno
 	return	res;
 }
 #define OPENCL_V_THROW(_status,_message) OpenCL_V_Throw (_status, _message, __LINE__)
+
+inline cl_int OpenCL_V_Warn(cl_int res, const std::string& msg, size_t lineno)
+{
+	switch (res)
+	{
+		case	CL_SUCCESS:		/**< No error */
+			break;
+		case	CL_DEVICE_NOT_FOUND:
+			// This happens all the time when discovering the OpenCL capabilities of the system,
+			// so do nothing here.
+			break;
+		default:
+		{
+			std::stringstream tmp;
+			tmp << "OPENCL_V_WARN< ";
+			tmp << prettyPrintclFFTStatus(res);
+			tmp << " > (";
+			tmp << lineno;
+			tmp << "): ";
+			tmp << msg;
+			std::string errorm(tmp.str());
+			std::cout << errorm << std::endl;
+		}
+	}
+
+	return	res;
+}
+#define OPENCL_V_WARN(_status,_message) OpenCL_V_Warn (_status, _message, __LINE__);
 
 /*
  * \brief Release OpenCL resources (Context, Memory etc.)

--- a/src/tests/cl_transform.h
+++ b/src/tests/cl_transform.h
@@ -264,7 +264,7 @@ public:
 			cl_context tempContext = NULL;
 			device_id = initializeCL(
 				device_type,
-				device_gpu_list,
+				dev_id,
 				tempContext,
 				printInfo
 			);

--- a/src/tests/gtest_main.cpp
+++ b/src/tests/gtest_main.cpp
@@ -59,6 +59,8 @@ bool suppress_output = false;
 //	Globals that user can set on the command line, that need to be passed down to unit tests
 cl_device_type device_type = CL_DEVICE_TYPE_GPU;
 cl_uint device_gpu_list = ~0x0;
+cl_int dev_id = -1;
+
 bool comparison_type = root_mean_square;
 
 int main( int argc, char **argv )
@@ -104,6 +106,7 @@ int main( int argc, char **argv )
 		( "noInfoCL",      "Don't print information from the OpenCL runtime" )
 		( "cpu,c",         "Run tests on a CPU device" )
 		( "gpu,g",         "Run tests on a GPU device (default)" )
+		("device", po::value< cl_int >(&dev_id)->default_value(-1), "Run tests on a specific OpenCL device id as reported by clInfo")
 		( "pointwise,p",         "Do a pointwise comparison to determine test correctness (default: use root mean square)" )
 		( "tolerance,t",        po::value< float >( &tolerance )->default_value( 0.001f ),   "tolerance level to use when determining test pass/fail" )
 		( "numRandom,r",        po::value< size_t >( &number_of_random_tests )->default_value( 2000 ),   "number of random tests to run" )
@@ -168,7 +171,7 @@ int main( int argc, char **argv )
 		cl_context tempContext = NULL;
 		cl_command_queue tempQueue = NULL;
 		cl_event tempEvent = NULL;
-		std::vector< cl_device_id > device_id = ::initializeCL( device_type, device_gpu_list, tempContext, true );
+		std::vector< cl_device_id > device_id = ::initializeCL(device_type, dev_id, tempContext, true);
 		::cleanupCL( &tempContext, &tempQueue, 0, NULL, 0, NULL, &tempEvent );
 	}
 

--- a/src/tests/test_constants.cpp
+++ b/src/tests/test_constants.cpp
@@ -88,7 +88,7 @@ size_t max_mem_available_on_cl_device(size_t device_index) {
 	cl_context tempContext = NULL;
 	device_id = initializeCL(
 		device_type,
-		device_gpu_list,
+		dev_id,
 		tempContext,
 		false
 		);

--- a/src/tests/test_constants.h
+++ b/src/tests/test_constants.h
@@ -63,6 +63,7 @@ extern float tolerance;
 
 extern cl_device_type device_type;
 extern cl_uint device_gpu_list;
+extern cl_int dev_id;
 
 extern size_t number_of_random_tests;
 extern time_t random_test_parameter_seed;

--- a/src/tests/unit_test.cpp
+++ b/src/tests/unit_test.cpp
@@ -29,12 +29,12 @@ protected:
 		lengths[ 0 ] = 32;
 		lengths[ 1 ] = 32;
 		lengths[ 2 ] = 32;
-		cl_uint	deviceGpuList = ~0; // a bitmap set
+		cl_int devId = -1;
 		commandQueueFlags = 0;
 
 		size_t memSizeBytes = lengths[ 0 ] * lengths[ 1 ] * lengths[ 2 ] * sizeof( std::complex< float > );
 
-		device_id = initializeCL( CL_DEVICE_TYPE_CPU, deviceGpuList, context, printInfo );
+		device_id = initializeCL( CL_DEVICE_TYPE_CPU, devId, context, printInfo );
 		createOpenCLCommandQueue( context,
 								  commandQueueFlags,
 								  queue,


### PR DESCRIPTION
In our environment we got several GPU and CPU devices in parallel and we should be able to profile them indepedently for FFT performance. clfft-client for now only uses the last reported OpenCL device in a given category as a default.

So this pull request is a patch that allows all OpenCL devices in a system to be enumerated (results printed out via "-i") and selected specifically with their id in clfft-client. The selection is possible via a new command-line parameter "--device [dev-id]". Without the parameter clfft-client defaults to its current behaviour, selecting the last reported OpenCL device.

Afaik, this pull would also be a fix for issue #20.

It's just an idea and sort of a "best-guess" implementation, but maybe it's of some use for the lib.
