### PR TITLE
don't force the usage of libc++ on mac

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -30,14 +30,8 @@ set( Client.Headers client.h
 
 set( Client.Files ${Client.Source} ${Client.Headers} )
 
-set( DL_LIB "" )
 if( WIN32 )
 	add_definitions( "/D_CONSOLE" )
-elseif( APPLE )
-	set( CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++ ${CMAKE_CXX_FLAGS}" )	
-else( )
-	# To use the dlopen() and dlclose() functions, we should link with libdl
-	set( DL_LIB "-ldl" )
 endif( )
 
 # Include standard OpenCL headers
@@ -45,7 +39,7 @@ include_directories( ${Boost_INCLUDE_DIRS} ${OPENCL_INCLUDE_DIRS} ../../../commo
 
 add_executable( clFFT-client ${Client.Files} )
 
-target_link_libraries( clFFT-client clFFT ${Boost_LIBRARIES} ${OPENCL_LIBRARIES} ${DL_LIB} )
+target_link_libraries( clFFT-client clFFT ${Boost_LIBRARIES} ${OPENCL_LIBRARIES} ${CMAKE_DL_LIBS} )
 
 set_target_properties( clFFT-client PROPERTIES VERSION ${CLFFT_VERSION} )
 set_target_properties( clFFT-client PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )


### PR DESCRIPTION
it is not the default c++ lib on 10.8 and older

also use cmake's CMAKE_DL_LIBS to link to `dl` when needed.