### PR TITLE
Install cmake configuration to lib/cmake/clFFT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,7 +290,7 @@ endif()
 if(WIN32)
   set(destdir CMake)
 else()
-  set(destdir share/clFFT)
+  set(destdir lib${SUFFIX_LIB}/cmake/clFFT)
 endif()
 string(REGEX REPLACE "[^/]+" ".." reldir "${destdir}")
 configure_file(


### PR DESCRIPTION
The cmake configuration should go to /usr/lib{64}/cmake/clFFT and not to /usr/share/clFFT.