### PR TITLE
Entry function fft_fwd uses too much shared data (0x401c bytes, 0x4000 max)

### DIFF
--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -493,6 +493,10 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 	{
 	case CLFFT_1D:
 		{
+			// Local memory isn't enough for all variables.
+			if ( Large1DThreshold <= 2048 )
+				Large1DThreshold /= 2;
+
 			if ( fftPlan->length[0] > Large1DThreshold )
 			{
 				size_t clLengths[] = { 1, 1, 0 };
@@ -513,6 +517,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						{
 							switch(fftPlan->length[0])
 							{
+							case 2048:		clLengths[1] = 64;	break;
 							case 8192:		clLengths[1] = 64;	break;
 							case 16384:		clLengths[1] = 64;	break;
 							case 32768:		clLengths[1] = 128;	break;

--- a/src/library/transform.cpp
+++ b/src/library/transform.cpp
@@ -126,6 +126,10 @@ clfftStatus clfftEnqueueTransform(
 	{
 		case CLFFT_1D:
 		{
+			// Local memory isn't enough for all variables.
+			if ( Large1DThreshold <= 2048 )
+				Large1DThreshold /= 2;
+
 			if (fftPlan->length[0] <= Large1DThreshold)
 				break;
 


### PR DESCRIPTION
Hi, 
When I use the 1D dimension and set the vector's size in 2048 I got the message above.
Probably it occurs because the local memory of the my graphic board is small, so I split the vector in half to solve this issue.

This little patch fixed the issue.
I have a graphic card NVIDIA 310m (linux x64 - driver NVIDIA 331).

Thank you