### PR TITLE
timer implementation for OS X

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -41,6 +41,29 @@ public:
     }
 };
 
+#elif defined(__APPLE__) || defined(__MACOSX)
+
+#include <mach/clock.h>
+#include <mach/mach.h>
+
+struct Timer
+{
+    clock_serv_t clock;
+    mach_timespec_t start, end;
+
+public:
+    Timer() { host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &clock); }
+    ~Timer() { mach_port_deallocate(mach_task_self(), clock); }
+
+    void Start() { clock_get_time(clock, &start); }
+    double Sample()
+    {
+        clock_get_time(clock, &end);
+        double time = 1000000000L * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
+        return time * 1E-9;
+    }
+};
+
 #else
 
 #include <time.h>


### PR DESCRIPTION
OS X doesn't have CLOCK_MONOTONIC so a different implementation is necessary.