### PR TITLE
add missing include on stdlib

### DIFF
--- a/src/library/fft_binary_lookup.cpp
+++ b/src/library/fft_binary_lookup.cpp
@@ -25,7 +25,7 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-
+#include <stdlib.h>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
On most architectures other than `amd64`, the build of `clFFT` fails with the following error:
```
[ 62%] Building CXX object library/CMakeFiles/clFFT.dir/fft_binary_lookup.cpp.o
cd /tmp/buildd/clfft-2.6.1/obj-i586-linux-gnu/library && /usr/bin/c++   -DCLFFT_EXPORTS -DclFFT_EXPORTS -pthread -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2  -O2 -g -DNDEBUG -fPIC -I/tmp/buildd/clfft-2.6.1/obj-i586-linux-gnu/include -I/tmp/buildd/clfft-2.6.1/src/library/../include    -o CMakeFiles/clFFT.dir/fft_binary_lookup.cpp.o -c /tmp/buildd/clfft-2.6.1/src/library/fft_binary_lookup.cpp
/tmp/buildd/clfft-2.6.1/src/library/fft_binary_lookup.cpp: In function 'void clfftInitBinaryCache()':
/tmp/buildd/clfft-2.6.1/src/library/fft_binary_lookup.cpp:66:50: error: 'getenv' was not declared in this scope
     const char * path = getenv("CLFFT_CACHE_PATH");
```

Adding the missing `#include <stdlib.h>` where `getenv` is declared solves the problem.