### PR TITLE
Fix redefinition warnings when using with clBLAS

### DIFF
--- a/src/library/fft_binary_lookup.cpp
+++ b/src/library/fft_binary_lookup.cpp
@@ -49,7 +49,7 @@ extern "C"
 
 #include <string.h>
 
-char * sep()
+static char * sep()
 {
 #ifdef __WIN32
     return (char*)"\\";
@@ -193,7 +193,7 @@ enum BinaryRepresentation
     UNKNOWN
 };
 
-enum BinaryRepresentation getStorageMode(char * data)
+static enum BinaryRepresentation getStorageMode(char * data)
 {
     if (data[0] == 'C' && 
         data[1] == 'L' && 


### PR DESCRIPTION
seq and getStorageMode are defined in both clBLAS and clFFT. This causes redefinition warnings when using both in the same project.
Opened PR in https://github.com/clMathLibraries/clBLAS/pull/135