### PR TITLE
Support FreeBSD in clFFT

### DIFF
--- a/src/include/sharedLibrary.h
+++ b/src/include/sharedLibrary.h
@@ -52,6 +52,14 @@ inline void* LoadSharedLibrary( std::string unixPrefix, std::string libraryName,
   {
           std::cerr << ::dlerror( ) << std::endl;
   }
+#elif defined(__FreeBSD__)
+        tstring freebsdName = unixPrefix;
+        freebsdName += libraryName += ".so";
+        void* fileHandle = ::dlopen( freebsdName.c_str( ), RTLD_NOW );
+        if( !quiet && !fileHandle )
+        {
+                std::cerr << ::dlerror( ) << std::endl;
+        }
 #else
         #error "unsupported platform"
 #endif

--- a/src/statTimer/statisticalTimer.CPU.h
+++ b/src/statTimer/statisticalTimer.CPU.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <algorithm>
 #ifdef __FreeBSD__
-#include <sys/timespec>
+#include <sys/timespec.h>
 #endif
 #include "statisticalTimer.h"
 

--- a/src/statTimer/statisticalTimer.CPU.h
+++ b/src/statTimer/statisticalTimer.CPU.h
@@ -21,6 +21,9 @@
 #include <iosfwd>
 #include <vector>
 #include <algorithm>
+#ifdef __FreeBSD__
+#include <sys/timespec>
+#endif
 #include "statisticalTimer.h"
 
 /**


### PR DESCRIPTION
Small changes that add support for FreeBSD in clFFT. These changes have similarly been incorporated into our math/clfft port.