### PR TITLE
use default doxygen settings for output directory

### DIFF
--- a/docs/clFFT.doxy
+++ b/docs/clFFT.doxy
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../../bindoc
+OUTPUT_DIRECTORY       = 
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and


### PR DESCRIPTION
There is no guarantee that the relative path `../../bindoc`, which is outside the source tree, will be user writeable. This PR restores the Doxygen default setting for OUTPUT_DIRECTORY, thereby placing the generating HTML directory under `doc/html`.