### PR TITLE
FIX: for float to string conversion always use '.' as comma separator…

### DIFF
--- a/src/library/generator.stockham.cpp
+++ b/src/library/generator.stockham.cpp
@@ -570,15 +570,13 @@ namespace StockhamGenerator
 
 			// Stringize the table
 			std::stringstream ss;
+			ss.imbue(std::locale("C"));
+			ss.precision(34);
 			for(size_t i = 0; i < (N-1); i++)
 			{
 				ss << "("; ss << RegBaseType<PR>(2); ss << ")(";
-
-				char cv[64], sv[64];
-				sprintf(cv, "%036.34lf", wc[i]);
-				sprintf(sv, "%036.34lf", ws[i]);
-				ss << cv; ss << sfx; ss << ", ";
-				ss << sv; ss << sfx; ss << "),\n";
+				ss << std::scientific << wc[i] << sfx << ", ";
+				ss << std::scientific << ws[i] << sfx << "),\n";
 			}
 			twStr += ss.str();
 		}

--- a/src/library/private.h
+++ b/src/library/private.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <string>
+#include <locale>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
…, independent of locale setting

As pointed out in geggo/gpyfft#15, clFFT produces invalid kernels, which contain numbers with ',' as decimal separator, when the locale settings imply this, e.g. for LC_NUMERIC = "de_AT". It seems it is enough to fix the kernel code generator for the twiddle table, but likely there are also other places that need to be fixed.

Here a short python script to test the behaviour (relying on geggo/gpyfft, I am a poor C++ programmer):

[test_locale.py](https://github.com/clMathLibraries/clFFT/files/32118/test_locale.txt)


Gregor