### PR TITLE
Fix HAVE_OPENSSL build

### DIFF
--- a/src/library/md5sum.c
+++ b/src/library/md5sum.c
@@ -34,6 +34,8 @@
  * optimizations are not included to reduce source code size and avoid
  * compile-time configuration.
  */
+
+#include "md5sum.h"
  
 #ifndef HAVE_OPENSSL
  
@@ -41,7 +43,6 @@
 #include <stdlib.h>
 #include <stdio.h>
  
-#include "md5sum.h"
  
 /*
  * The basic MD5 functions.
@@ -295,7 +296,7 @@ void MD5_Final(unsigned char *result, MD5_CTX *ctx)
 	memset(ctx, 0, sizeof(*ctx));
 }
  
-#endif
+#endif // HAVE_OPENSSL
 
 void md5sum(const void * data, unsigned long size, char * md5string)
 {

--- a/src/library/md5sum.h
+++ b/src/library/md5sum.h
@@ -23,10 +23,12 @@
  * See md5.c for more information.
  */
 
+#ifndef _MD5_H
+#define _MD5_H
+
 #ifdef HAVE_OPENSSL
 #include <openssl/md5.h>
-#elif !defined(_MD5_H)
-#define _MD5_H
+#else
 
 /* Any 32-bit or wider unsigned integer data type will do */
 typedef unsigned int MD5_u32plus;
@@ -42,9 +44,8 @@ extern void MD5_Init(MD5_CTX *ctx);
 extern void MD5_Update(MD5_CTX *ctx, const void *data, unsigned long size);
 extern void MD5_Final(unsigned char *result, MD5_CTX *ctx);
 
+#endif // HAVE_OPENSSL
+
 void md5sum (const void * data, unsigned long size, char * md5sum);
 
-
-
-#endif
-
+#endif // _MD5_H


### PR DESCRIPTION
 - Move md5sum() declaration outside HAVE_OPENSSL guard as this
   function isn't provided by OpenSSL.

 - Move `#include "md5sum.h"` outside HAVE_OPENSSL guard as the
   header file includes OpenSSL headers required by md5sum().