### PR TITLE
Fix for google test. XML does not support spaces in property names

### DIFF
--- a/src/tests/accuracy_test_random.cpp
+++ b/src/tests/accuracy_test_random.cpp
@@ -533,7 +533,7 @@ namespace ParameterizedTest {
 			the_seed( seed_in )
 		{
 			random_parameter_generator.seed( static_cast<boost::uint32_t>( the_seed ) );
-			::testing::Test::RecordProperty("parameter seed", static_cast<unsigned int>(the_seed));
+			::testing::Test::RecordProperty("parameter_seed", static_cast<unsigned int>(the_seed));
 			std::cout << "Random test's seed is " << the_seed << std::endl;
 		}
 	};


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clfft/135)
<!-- Reviewable:end -->
