### PR TITLE
Enable support for kFreeBSD.

### DIFF
--- a/src/include/sharedLibrary.h
+++ b/src/include/sharedLibrary.h
@@ -52,7 +52,7 @@ inline void* LoadSharedLibrary( std::string unixPrefix, std::string libraryName,
   {
           std::cerr << ::dlerror( ) << std::endl;
   }
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD_kernel__)
         tstring freebsdName = unixPrefix;
         freebsdName += libraryName += ".so";
         void* fileHandle = ::dlopen( freebsdName.c_str( ), RTLD_NOW );


### PR DESCRIPTION
Replace usage of the `__FreeBSD__` macro with `__FreeBSD_kernel__` which enables support for both the FreeBSD and GNU/kFreeBSD kernels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clfft/138)
<!-- Reviewable:end -->
