### PR TITLE
add general inplace transpose kernels

### DIFF
--- a/src/library/action.transpose.cpp
+++ b/src/library/action.transpose.cpp
@@ -335,6 +335,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::getWorkSizes(std::vector< size
     if (this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED_LEADING  
         || this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED)
     {
+        std::cout << "TIMMY"<< std::endl;
         if (smaller_dim % (16 * reShapeFactor) == 0)
             wg_slice = smaller_dim / 16 / reShapeFactor;
         else
@@ -350,7 +351,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::getWorkSizes(std::vector< size
         /*Push the data required for the transpose kernels*/
         globalWS.clear();
 		if(this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED_LEADING)
-			globalWS.push_back(global_item_size * 2);
+			globalWS.push_back(global_item_size * dim_ratio);
 		else if (this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED)
 			globalWS.push_back(global_item_size);
 
@@ -441,10 +442,11 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::getWorkSizes(std::vector< size
 			{
 				//1:3 ratio
 				size_t local_work_size_swap = 256;
-				std::vector<std::vector<size_t>> permutationTable;
+				std::vector<std::vector<size_t> > permutationTable;
 				clfft_transpose_generator::permutation_calculation(dim_ratio, smaller_dim, permutationTable);
 				size_t global_item_size = permutationTable.size() * local_work_size_swap * this->plan->batchsize;
-
+                for (int i = 2; i < this->plan->length.size(); i++)
+                    global_item_size *= this->plan->length[i];
 				globalWS.push_back(global_item_size);
 				localWS.push_back(local_work_size_swap);
 			}

--- a/src/library/action.transpose.cpp
+++ b/src/library/action.transpose.cpp
@@ -135,8 +135,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::initParams()
     }
 
     this->signature.fft_DataDim = this->plan->length.size() + 1;
-	//if (this->plan->length.back() == 729 && this->plan->length.size() > 2)//silly Timmy delete
-	//	this->signature.fft_DataDim--;
+
     int i = 0;
     for (i = 0; i < (this->signature.fft_DataDim - 1); i++)
     {
@@ -700,7 +699,6 @@ clfftStatus FFTGeneratedTransposeSquareAction::generateKernel(FFTRepo& fftRepo, 
 
 	std::string programCode;
 	OPENCL_V(clfft_transpose_generator::genTransposeKernelBatched(this->signature, programCode, lwSize, reShapeFactor), _T("GenerateTransposeKernel() failed!"));
-	//std::cout << programCode << std::endl;//TIMMY
 
 	cl_int status = CL_SUCCESS;
 	cl_device_id Device = NULL;

--- a/src/library/action.transpose.cpp
+++ b/src/library/action.transpose.cpp
@@ -222,7 +222,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::generateKernel(FFTRepo& fftRep
 			}
 		}
         OPENCL_V(clfft_transpose_generator::genTransposeKernelLeadingDimensionBatched(this->signature, programCode, lwSize, reShapeFactor), _T("genTransposeKernel() failed!"));
-		std::cout << programCode << std::endl;//TIMMY
+		//std::cout << programCode << std::endl;//TIMMY
     }
 	else if (this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED)
 	{
@@ -246,7 +246,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::generateKernel(FFTRepo& fftRep
 			}
 		}
 		OPENCL_V(clfft_transpose_generator::genTransposeKernelBatched(this->signature, programCode, lwSize, reShapeFactor), _T("genTransposeKernel() failed!"));
-		std::cout << programCode << std::endl;//TIMMY
+		//std::cout << programCode << std::endl;//TIMMY
 	}
     else
     {
@@ -282,7 +282,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::generateKernel(FFTRepo& fftRep
 		*/
 		//general swap kernel takes care of all ratio
 		OPENCL_V(clfft_transpose_generator::genSwapKernelGeneral(this->signature, programCode, kernelFuncName, lwSize, reShapeFactor), _T("genSwapKernel() failed!"));
-		std::cout << programCode << std::endl;//TIMMY
+		//std::cout << programCode << std::endl;//TIMMY
     }
 
     cl_int status = CL_SUCCESS;
@@ -349,7 +349,6 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::getWorkSizes(std::vector< size
 
     if (this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED_LEADING)
     {
-        std::cout << "TIMMY"<< std::endl;
         if (smaller_dim % (16 * reShapeFactor) == 0)
             wg_slice = smaller_dim / 16 / reShapeFactor;
         else
@@ -375,7 +374,6 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::getWorkSizes(std::vector< size
     }
 	else if (this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED)
 	{
-		std::cout << "TIMMY" << std::endl;
 		if (smaller_dim % (16 * reShapeFactor) == 0)
 			wg_slice = smaller_dim / 16 / reShapeFactor;
 		else
@@ -383,7 +381,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::getWorkSizes(std::vector< size
 
 		global_item_size = wg_slice*(wg_slice + 1) / 2 * 16 * 16 * this->plan->batchsize;
 
-		for (int i = 2; i < this->plan->length.size(); i++)//Timmy delete
+		for (int i = 2; i < this->plan->length.size(); i++)
 		{
 			global_item_size *= this->plan->length[i];
 		}
@@ -721,7 +719,7 @@ clfftStatus FFTGeneratedTransposeSquareAction::generateKernel(FFTRepo& fftRepo, 
 	{
 		OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_SQUARE, this->getSignatureData(), "transpose_square", "transpose_square", Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
 	}
-    std::cout << programCode << std::endl;//TIMMY
+    //std::cout << programCode << std::endl;//TIMMY
 	return CLFFT_SUCCESS;
 }
 

--- a/src/library/action.transpose.cpp
+++ b/src/library/action.transpose.cpp
@@ -183,6 +183,7 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::initParams()
 	this->signature.limit_LocalMemSize = this->plan->envelope.limit_LocalMemSize;
 
 	this->signature.transposeMiniBatchSize = this->plan->transposeMiniBatchSize;
+	this->signature.nonSquareKernelOrder = this->plan->nonSquareKernelOrder;
 	this->signature.transposeBatchSize = this->plan->batchsize;
 
     return CLFFT_SUCCESS;

--- a/src/library/action.transpose.cpp
+++ b/src/library/action.transpose.cpp
@@ -311,7 +311,9 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::generateKernel(FFTRepo& fftRep
     }
 	else if(this->signature.nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED)
 	{
-		if (this->signature.fft_3StepTwiddle && (this->signature.transposeMiniBatchSize == 1)) //if miniBatchSize > 1 twiddling is done in swap kernel
+        //for non square we do twiddling in swap kernel
+        /*
+		if (this->signature.fft_3StepTwiddle && (this->signature.transposeMiniBatchSize == 1))
 		{
 			OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_NONSQUARE, this->getSignatureData(), "transpose_square_tw_fwd", "transpose_square_tw_back", Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
 		}
@@ -319,11 +321,19 @@ clfftStatus FFTGeneratedTransposeNonSquareAction::generateKernel(FFTRepo& fftRep
 		{
 			OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_NONSQUARE, this->getSignatureData(), "transpose_square", "transpose_square", Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
 		}
+        */
+        OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_NONSQUARE, this->getSignatureData(), "transpose_square", "transpose_square", Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
 	}
     else
     {
-		//this should be modified as well
-        OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_NONSQUARE, this->getSignatureData(), kernelFuncName.c_str(), kernelFuncName.c_str(), Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
+        if (this->signature.fft_3StepTwiddle)//if miniBatchSize > 1 twiddling is done in swap kernel
+        {
+            std::string kernelFwdFuncName = kernelFuncName + "_tw_fwd";
+            std::string kernelBwdFuncName = kernelFuncName + "_tw_back";
+            OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_NONSQUARE, this->getSignatureData(), kernelFwdFuncName.c_str(), kernelBwdFuncName.c_str(), Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
+        }
+        else
+            OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_NONSQUARE, this->getSignatureData(), kernelFuncName.c_str(), kernelFuncName.c_str(), Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
     }
     return CLFFT_SUCCESS;
 }

--- a/src/library/action.transpose.cpp
+++ b/src/library/action.transpose.cpp
@@ -654,7 +654,7 @@ clfftStatus FFTGeneratedTransposeSquareAction::generateKernel(FFTRepo& fftRepo, 
 	{
 		OPENCL_V(fftRepo.setProgramEntryPoints(Transpose_SQUARE, this->getSignatureData(), "transpose_square", "transpose_square", Device, QueueContext), _T("fftRepo.setProgramEntryPoint() failed!"));
 	}
-
+    std::cout << programCode << std::endl;//TIMMY
 	return CLFFT_SUCCESS;
 }
 

--- a/src/library/enqueue.cpp
+++ b/src/library/enqueue.cpp
@@ -625,6 +625,15 @@ clfftStatus FFTAction::enqueue(clfftPlanHandle plHandle,
     std::vector< size_t > lWorkSize;
     clfftStatus result = this->getWorkSizes (gWorkSize, lWorkSize);
 	//std::cout << "work sizes are " << gWorkSize[0] << ", " << lWorkSize[0] << std::endl;
+	/*
+	std::cout << "work sizes are ";
+	for (auto itor = gWorkSize.begin(); itor != gWorkSize.end(); itor++)
+		std::cout << *itor << " ";
+	std::cout << ", ";
+	for (auto itor = lWorkSize.begin(); itor != lWorkSize.end(); itor++)
+		std::cout << *itor << " ";
+	std::cout << std::endl;
+	*/
     // TODO:  if getWorkSizes returns CLFFT_INVALID_GLOBAL_WORK_SIZE, that means
     // that this multidimensional input data array is too large to be transformed
     // with a single call to clEnqueueNDRangeKernel.  For now, we will just return

--- a/src/library/enqueue.cpp
+++ b/src/library/enqueue.cpp
@@ -624,7 +624,7 @@ clfftStatus FFTAction::enqueue(clfftPlanHandle plHandle,
     std::vector< size_t > gWorkSize;
     std::vector< size_t > lWorkSize;
     clfftStatus result = this->getWorkSizes (gWorkSize, lWorkSize);
-
+	std::cout << "work sizes are " << gWorkSize[0] << ", " << lWorkSize[0] << std::endl;
     // TODO:  if getWorkSizes returns CLFFT_INVALID_GLOBAL_WORK_SIZE, that means
     // that this multidimensional input data array is too large to be transformed
     // with a single call to clEnqueueNDRangeKernel.  For now, we will just return

--- a/src/library/enqueue.cpp
+++ b/src/library/enqueue.cpp
@@ -624,7 +624,7 @@ clfftStatus FFTAction::enqueue(clfftPlanHandle plHandle,
     std::vector< size_t > gWorkSize;
     std::vector< size_t > lWorkSize;
     clfftStatus result = this->getWorkSizes (gWorkSize, lWorkSize);
-	std::cout << "work sizes are " << gWorkSize[0] << ", " << lWorkSize[0] << std::endl;
+	//std::cout << "work sizes are " << gWorkSize[0] << ", " << lWorkSize[0] << std::endl;
     // TODO:  if getWorkSizes returns CLFFT_INVALID_GLOBAL_WORK_SIZE, that means
     // that this multidimensional input data array is too large to be transformed
     // with a single call to clEnqueueNDRangeKernel.  For now, we will just return

--- a/src/library/generator.transpose.cpp
+++ b/src/library/generator.transpose.cpp
@@ -38,7 +38,6 @@ void OffsetCalc(std::stringstream& transKernel, const FFTKernelGenKeyParams& par
 	for (size_t i = params.fft_DataDim - 2; i > 0; i--)
 	{
 		clKernWrite(transKernel, 3) << offset << " += (g_index/numGroupsY_" << i << ")*" << stride[i + 1] << ";" << std::endl;
-		//clKernWrite(transKernel, 3) << offset << " += (g_index/numGroupsY_" << i << ")*" << 1048576 << ";" << std::endl;
 		clKernWrite(transKernel, 3) << "g_index = g_index % numGroupsY_" << i << ";" << std::endl;
 	}
 

--- a/src/library/generator.transpose.cpp
+++ b/src/library/generator.transpose.cpp
@@ -1931,7 +1931,6 @@ clfftStatus genSwapKernelGeneral(const FFTGeneratedTransposeNonSquareAction::Sig
     }//end of for (size_t bothDir = 0; bothDir < 2; bothDir++)
 	
 
-	//std::cout << transKernel.str();
 	//by now the kernel string is generated
 	strKernel = transKernel.str();
 	return CLFFT_SUCCESS;

--- a/src/library/generator.transpose.h
+++ b/src/library/generator.transpose.h
@@ -52,11 +52,14 @@ Below is a matrix(row major) contaning three square sub matrix along row
 */
 clfftStatus genTransposeKernelLeadingDimensionBatched(const FFTGeneratedTransposeNonSquareAction::Signature & params, std::string& strKernel, const size_t& lwSize, const size_t reShapeFactor);
 
-//swap lines. This kind of kernels are using with combination of square transpose kernels to perform nonsqaure transpose
-clfftStatus genSwapKernel(const FFTGeneratedTransposeNonSquareAction::Signature & params, std::string& strKernel, const size_t& lwSize, const size_t reShapeFactor);
+//swap lines. This kind of kernels are using with combination of square transpose kernels to perform nonsqaure transpose 1:2 ratio
+clfftStatus genSwapKernel(const FFTGeneratedTransposeNonSquareAction::Signature & params, std::string& strKernel, std::string& KernelFuncName, const size_t& lwSize, const size_t reShapeFactor);
+
+clfftStatus genSwapKernelGeneral(const FFTGeneratedTransposeNonSquareAction::Signature & params, std::string& strKernel, std::string& KernelFuncName, const size_t& lwSize, const size_t reShapeFactor);
 
 void get_cycles(size_t *cycle_map, size_t num_reduced_row, size_t num_reduced_col);
 
+void permutation_calculation(size_t m, size_t n, std::vector<std::vector<size_t>> &permutationVec);
 }//end of namespace clfft_transpose_generator
 
 #endif

--- a/src/library/generator.transpose.h
+++ b/src/library/generator.transpose.h
@@ -59,7 +59,7 @@ clfftStatus genSwapKernelGeneral(const FFTGeneratedTransposeNonSquareAction::Sig
 
 void get_cycles(size_t *cycle_map, size_t num_reduced_row, size_t num_reduced_col);
 
-void permutation_calculation(size_t m, size_t n, std::vector<std::vector<size_t>> &permutationVec);
+void permutation_calculation(size_t m, size_t n, std::vector<std::vector<size_t> > &permutationVec);
 }//end of namespace clfft_transpose_generator
 
 #endif

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -610,8 +610,16 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					}
 				}
 				// add some special cases
+				if (fftPlan->length[0] == 10000)
+					clLengths[1] = 100;//100 x 100
 				if (fftPlan->length[0] == 100000)
-					clLengths[1] = 100;
+					clLengths[1] = 100;//100 x 1,000
+				if (fftPlan->length[0] == 10000000)
+					clLengths[1] = 1000;//1,000 x 10,000
+				if (fftPlan->length[0] == 100000000)
+					clLengths[1] = 10000;//10,000 x 10,000
+				if (fftPlan->length[0] == 1000000000)
+					clLengths[1] = 10000;//10,000 x 100,000
 
 				clLengths[0] = fftPlan->length[0]/clLengths[1];
 				//timmy ensure clLengths[0] > clLengths[1] only when inplace is enabled 
@@ -655,8 +663,10 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						 (clLengths[0] == 10 * clLengths[1])) &&
 						fftPlan->placeness == CLFFT_INPLACE)
 						*/
-					size_t dim_ratio = clLengths[1] / clLengths[0];
+					size_t dim_ratio = biggerDim / smallerDim;
+					size_t dim_residue = biggerDim % smallerDim;
 					if (clfftGetRequestLibNoMemAlloc() &&
+						dim_residue == 0 &&
 						((dim_ratio % 2 == 0) ||
 						 (dim_ratio % 3 == 0) ||
 						 (dim_ratio % 5 == 0) ||

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -656,6 +656,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						transGen = Transpose_SQUARE;
 					}
 
+
 					if ( (fftPlan->tmpBufSize==0 ) && !fftPlan->allOpsInplace)
 					{
 						fftPlan->tmpBufSize = (smallerDim + padding) * biggerDim *
@@ -1998,14 +1999,14 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 							}
 							else
 							{
-								currKernelOrder = TRANSPOSE_AND_SWAP;//TRANSPOSE_AND_SWAP TIMMY TEMP
+								currKernelOrder = TRANSPOSE_AND_SWAP;
 							}
 						}
 						//if the original input data is more than 1d only TRANSPOSE_LEADING_AND_SWAP order is supported
 						//TODO need to fix this here. related to multi dim batch size.
 						if (fftPlan->length.size() > 2)
 							currKernelOrder = TRANSPOSE_LEADING_AND_SWAP;
-                        std::cout << "transpose kernel order is " << currKernelOrder << std::endl;
+						std::cout << "currKernelOrder = " << currKernelOrder << std::endl;
 						//ends tranpose kernel order
 
 						//Transpose stage 1 

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -961,10 +961,10 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 							the iDist should decrease accordingly. Push back to length will cause a 3D transpose
 							*/
 							trans3Plan->batchsize = trans3Plan->batchsize * fftPlan->length[index];
-							trans3Plan->iDist = trans3Plan->iDist / fftPlan->length[index];
+							//trans3Plan->iDist = trans3Plan->iDist / fftPlan->length[index];//silly Timmy
 							//trans3Plan->inStride.push_back(trans3Plan->iDist);
 							trans3Plan->inStride.push_back(fftPlan->inStride[index]);
-							trans3Plan->iDist *= fftPlan->length[index];
+							//trans3Plan->iDist *= fftPlan->length[index];//silly Timmy
 							trans3Plan->outStride.push_back(fftPlan->outStride[index]);
 						}
 					}

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -609,7 +609,9 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						}
 					}
 				}
-
+				// add some special cases
+				if (fftPlan->length[0] == 100000)
+					clLengths[1] = 100;
 				clLengths[0] = fftPlan->length[0]/clLengths[1];
 
                 // Start of block where transposes are generated; 1D FFT
@@ -781,7 +783,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					trans2Plan->oDist         = clLengths[1] * trans2Plan->outStride[1];
                     trans2Plan->gen           = transGen;
 
-					if(transGen != Transpose_NONSQUARE)//TIMMY twiddle
+					if (transGen != Transpose_NONSQUARE)//TIMMY twiddle
 						trans2Plan->large1D		  = fftPlan->length[0];
 
 					trans2Plan->transflag     = true;
@@ -837,7 +839,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						row2Plan->oDist *= fftPlan->length[index];
 					}
 					
-					if (transGen == Transpose_NONSQUARE)//TIMMY twiddle
+					if (transGen != Transpose_NONSQUARE)//TIMMY twiddle in transform
 					{
 						row2Plan->large1D = fftPlan->length[0];
 						row2Plan->twiddleFront = true;
@@ -1991,7 +1993,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						}
 						else
 						{
-							if (fftPlan->large1D != 0)
+							if (fftPlan->large1D != 0 && 0)
 							{
 								//currently tranpose twiddling is only supported in below case
 								//TODO support tranpose twiddling for all cases.
@@ -2004,8 +2006,8 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						}
 						//if the original input data is more than 1d only TRANSPOSE_LEADING_AND_SWAP order is supported
 						//TODO need to fix this here. related to multi dim batch size.
-						if (fftPlan->length.size() > 2)
-							currKernelOrder = TRANSPOSE_LEADING_AND_SWAP;
+						//if (fftPlan->length.size() > 2) //Timmy test
+						//	currKernelOrder = TRANSPOSE_LEADING_AND_SWAP;
 						std::cout << "currKernelOrder = " << currKernelOrder << std::endl;
 						//ends tranpose kernel order
 
@@ -2038,7 +2040,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						else
 							trans1Plan->nonSquareKernelType = NON_SQUARE_TRANS_TRANSPOSE_BATCHED_LEADING;
 						trans1Plan->transflag = true;
-                        trans1Plan->large1D = fftPlan->large1D;
+                        trans1Plan->large1D = fftPlan->large1D;//twiddling may happen in this kernel
 
 						if (trans1Plan->nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED)
 						{
@@ -2111,6 +2113,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						else
 							trans2Plan->nonSquareKernelType = NON_SQUARE_TRANS_SWAP;
 						trans2Plan->transflag = true;
+						trans2Plan->large1D = fftPlan->large1D;//twiddling may happen in this kernel
 
 						if (trans2Plan->nonSquareKernelType == NON_SQUARE_TRANS_TRANSPOSE_BATCHED)
 						{

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -697,7 +697,9 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 
 					for (size_t index = 1; index < fftPlan->length.size(); index++)
 					{
-						trans1Plan->length.push_back(fftPlan->length[index]);
+						//trans1Plan->length.push_back(fftPlan->length[index]);
+						trans1Plan->batchsize = trans1Plan->batchsize * fftPlan->length[index];//Timmy
+						trans1Plan->iDist = trans1Plan->iDist / fftPlan->length[index];//Timmy
 						trans1Plan->inStride.push_back(fftPlan->inStride[index]);
 						trans1Plan->outStride.push_back(trans1Plan->oDist);
 						trans1Plan->oDist *= fftPlan->length[index];
@@ -783,14 +785,16 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					trans2Plan->oDist         = clLengths[1] * trans2Plan->outStride[1];
                     trans2Plan->gen           = transGen;
 
-					if (transGen != Transpose_NONSQUARE)//TIMMY twiddle
+					//if (transGen != Transpose_NONSQUARE)//TIMMY twiddle
 						trans2Plan->large1D		  = fftPlan->length[0];
 
 					trans2Plan->transflag     = true;
 
 					for (size_t index = 1; index < fftPlan->length.size(); index++)
 					{
-						trans2Plan->length.push_back(fftPlan->length[index]);
+						//trans2Plan->length.push_back(fftPlan->length[index]);
+						trans2Plan->batchsize = trans2Plan->batchsize * fftPlan->length[index];//Timmy
+						trans2Plan->iDist = trans2Plan->iDist / fftPlan->length[index];//Timmy
 						trans2Plan->inStride.push_back(fftPlan->outStride[index]);
 						trans2Plan->outStride.push_back(trans2Plan->oDist);
 						trans2Plan->oDist *= fftPlan->length[index];
@@ -839,11 +843,11 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						row2Plan->oDist *= fftPlan->length[index];
 					}
 					
-					if (transGen != Transpose_NONSQUARE)//TIMMY twiddle in transform
-					{
-						row2Plan->large1D = fftPlan->length[0];
-						row2Plan->twiddleFront = true;
-					}
+					//if (transGen != Transpose_NONSQUARE)//TIMMY twiddle in transform
+					//{
+					//	row2Plan->large1D = fftPlan->length[0];
+					//	row2Plan->twiddleFront = true;
+					//}
 
 					OPENCL_V(clfftBakePlan(fftPlan->planY, numQueues, commQueueFFT, NULL, NULL ),
 						_T( "BakePlan large1d second row plan failed" ) );
@@ -876,7 +880,9 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 
 					for (size_t index = 1; index < fftPlan->length.size(); index++)
 					{
-						trans3Plan->length.push_back(fftPlan->length[index]);
+						//trans3Plan->length.push_back(fftPlan->length[index]);
+						trans3Plan->batchsize = trans3Plan->batchsize * fftPlan->length[index];//Timmy for 2D
+						trans3Plan->iDist = trans3Plan->iDist / fftPlan->length[index];//Timmy
 						trans3Plan->inStride.push_back(trans3Plan->iDist);
 						trans3Plan->iDist *= fftPlan->length[index];
 						trans3Plan->outStride.push_back(fftPlan->outStride[index]);

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -623,7 +623,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 
 				clLengths[0] = fftPlan->length[0]/clLengths[1];
 				//timmy ensure clLengths[0] > clLengths[1] only when inplace is enabled 
-				//so that swap kernel is launched after the square transpose kernel since twiddling is only enabled as the second kernel
+				//so that swap kernel is launched after the square transpose kernel since twiddling is only enabled in swap kernel if it is the second kernel
 				if (clLengths[0] < clLengths[1] && clfftGetRequestLibNoMemAlloc() && fftPlan->placeness == CLFFT_INPLACE)
 				{
 					std::cout << "switch lengths" << std::endl;
@@ -2107,7 +2107,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						{
 							if (fftPlan->large1D != 0 && 0)
 							{
-                                //this is not going to happen
+                                //this is not going to happen anymore
 								currKernelOrder = TRANSPOSE_LEADING_AND_SWAP;
 							}
 							else

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -1998,13 +1998,14 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 							}
 							else
 							{
-								currKernelOrder = TRANSPOSE_AND_SWAP;
+								currKernelOrder = TRANSPOSE_AND_SWAP;//TRANSPOSE_AND_SWAP TIMMY TEMP
 							}
 						}
 						//if the original input data is more than 1d only TRANSPOSE_LEADING_AND_SWAP order is supported
 						//TODO need to fix this here. related to multi dim batch size.
 						if (fftPlan->length.size() > 2)
 							currKernelOrder = TRANSPOSE_LEADING_AND_SWAP;
+                        std::cout << "transpose kernel order is " << currKernelOrder << std::endl;
 						//ends tranpose kernel order
 
 						//Transpose stage 1 

--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -698,8 +698,15 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					for (size_t index = 1; index < fftPlan->length.size(); index++)
 					{
 						//trans1Plan->length.push_back(fftPlan->length[index]);
-						trans1Plan->batchsize = trans1Plan->batchsize * fftPlan->length[index];//Timmy
-						trans1Plan->iDist = trans1Plan->iDist / fftPlan->length[index];//Timmy
+                        /*
+                        replacing the line above with the two lines below since:
+                        fftPlan is still 1D, thus the broken down transpose should be 2D not 3D
+                        the batchSize for the transpose should increase accordingly. 
+                        the iDist should decrease accordingly. Push back to length will cause a 3D transpose 
+                        */
+						trans1Plan->batchsize = trans1Plan->batchsize * fftPlan->length[index];
+						trans1Plan->iDist = trans1Plan->iDist / fftPlan->length[index];
+
 						trans1Plan->inStride.push_back(fftPlan->inStride[index]);
 						trans1Plan->outStride.push_back(trans1Plan->oDist);
 						trans1Plan->oDist *= fftPlan->length[index];
@@ -785,7 +792,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					trans2Plan->oDist         = clLengths[1] * trans2Plan->outStride[1];
                     trans2Plan->gen           = transGen;
 
-					//if (transGen != Transpose_NONSQUARE)//TIMMY twiddle
+					//if (transGen != Transpose_NONSQUARE)//twiddle
 						trans2Plan->large1D		  = fftPlan->length[0];
 
 					trans2Plan->transflag     = true;
@@ -793,8 +800,14 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					for (size_t index = 1; index < fftPlan->length.size(); index++)
 					{
 						//trans2Plan->length.push_back(fftPlan->length[index]);
-						trans2Plan->batchsize = trans2Plan->batchsize * fftPlan->length[index];//Timmy
-						trans2Plan->iDist = trans2Plan->iDist / fftPlan->length[index];//Timmy
+                        /*
+                        replacing the line above with the two lines below since:
+                        fftPlan is still 1D, thus the broken down transpose should be 2D not 3D
+                        the batchSize for the transpose should increase accordingly.
+                        the iDist should decrease accordingly. Push back to length will cause a 3D transpose
+                        */
+						trans2Plan->batchsize = trans2Plan->batchsize * fftPlan->length[index];
+						trans2Plan->iDist = trans2Plan->iDist / fftPlan->length[index];
 						trans2Plan->inStride.push_back(fftPlan->outStride[index]);
 						trans2Plan->outStride.push_back(trans2Plan->oDist);
 						trans2Plan->oDist *= fftPlan->length[index];
@@ -843,7 +856,7 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						row2Plan->oDist *= fftPlan->length[index];
 					}
 					
-					//if (transGen != Transpose_NONSQUARE)//TIMMY twiddle in transform
+					//if (transGen != Transpose_NONSQUARE)//twiddle in transform
 					//{
 					//	row2Plan->large1D = fftPlan->length[0];
 					//	row2Plan->twiddleFront = true;
@@ -881,8 +894,14 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 					for (size_t index = 1; index < fftPlan->length.size(); index++)
 					{
 						//trans3Plan->length.push_back(fftPlan->length[index]);
-						trans3Plan->batchsize = trans3Plan->batchsize * fftPlan->length[index];//Timmy for 2D
-						trans3Plan->iDist = trans3Plan->iDist / fftPlan->length[index];//Timmy
+                        /*
+                        replacing the line above with the two lines below since:
+                        fftPlan is still 1D, thus the broken down transpose should be 2D not 3D
+                        the batchSize for the transpose should increase accordingly.
+                        the iDist should decrease accordingly. Push back to length will cause a 3D transpose
+                        */
+						trans3Plan->batchsize = trans3Plan->batchsize * fftPlan->length[index];
+						trans3Plan->iDist = trans3Plan->iDist / fftPlan->length[index];
 						trans3Plan->inStride.push_back(trans3Plan->iDist);
 						trans3Plan->iDist *= fftPlan->length[index];
 						trans3Plan->outStride.push_back(fftPlan->outStride[index]);
@@ -1993,20 +2012,21 @@ clfftStatus	clfftBakePlan( clfftPlanHandle plHandle, cl_uint numQueues, cl_comma
 						NON_SQUARE_KERNEL_ORDER currKernelOrder;
 						// controling the transpose and swap kernel order
 						// if leading dim is larger than the other dim it makes sense to swap and transpose
-						if (clLengths[0] > clLengths[1])
+						if (clLengths[0] > clLengths[1] && fftPlan->large1D == 0)
 						{
+                            //twidding can be done in swap when swap is the second kernel for now
 							currKernelOrder = SWAP_AND_TRANSPOSE;
 						}
 						else
 						{
 							if (fftPlan->large1D != 0 && 0)
 							{
-								//currently tranpose twiddling is only supported in below case
-								//TODO support tranpose twiddling for all cases.
+                                //this is not going to happen
 								currKernelOrder = TRANSPOSE_LEADING_AND_SWAP;
 							}
 							else
 							{
+                                //twiddling can be done in swap
 								currKernelOrder = TRANSPOSE_AND_SWAP;
 							}
 						}

--- a/src/tests/accuracy_test_postcallback.cpp
+++ b/src/tests/accuracy_test_postcallback.cpp
@@ -2734,5 +2734,294 @@ TEST_F(accuracy_test_postcallback_double, pow5_large_3D_out_of_place_hermitian_i
 	catch( const std::exception& err ) { handle_exception(err);	}
 }
 
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^ huge 1D ^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+
+// *****************************************************
+// *****************************************************
+
+template< class T, class cl_T, class fftw_T>
+void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSize, layout::buffer_layout_t layoutType, direction::direction_t direction_type)
+{
+	std::vector<size_t> lengths;
+	lengths.push_back(lenSize);
+	size_t batch = batchSize;
+	std::vector<size_t> input_strides;
+	std::vector<size_t> output_strides;
+	size_t input_distance = 0;
+	size_t output_distance = 0;
+	layout::buffer_layout_t in_layout = layoutType;
+	layout::buffer_layout_t out_layout = layoutType;
+	placeness::placeness_t placeness = placeness::in_place;
+	direction::direction_t direction = direction_type;
+
+	data_pattern pattern = sawtooth;
+	postcallback_complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
+}
+
+//177147 = 243 * 243 * 3, forward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+//interleaved
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1594323 = 729 * 729 * 3 foward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//14348907 = 2187 * 2187 * 3 backward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//78125 = 125 * 125 * 5, forward planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1953125 = 625 * 625 * 5 forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//48828125 = 3125 * 3125 * 5 forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
 #pragma endregion
 } //namespace

--- a/src/tests/accuracy_test_postcallback.cpp
+++ b/src/tests/accuracy_test_postcallback.cpp
@@ -2759,265 +2759,269 @@ void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSiz
 	data_pattern pattern = sawtooth;
 	postcallback_complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
 }
+//TESTS disabled by default since they take a long time to execute
+//TO enable this tests
+//1. make sure ENV CLFFT_REQUEST_LIB_NOMEMALLOC=1
+//2. pass --gtest_also_run_disabled_tests to TEST.exe
 
 //177147 = 243 * 243 * 3, forward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 //interleaved
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //1594323 = 729 * 729 * 3 foward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //14348907 = 2187 * 2187 * 3 backward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //78125 = 125 * 125 * 5, forward planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //1953125 = 625 * 625 * 5 forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //48828125 = 3125 * 3125 * 5 forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_postcallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_postcallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_postcallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }

--- a/src/tests/accuracy_test_pow2.cpp
+++ b/src/tests/accuracy_test_pow2.cpp
@@ -1297,6 +1297,10 @@ TEST_F(accuracy_test_pow2_double, large_1D_forward_in_place_complex_planar_to_co
 
 // *****************************************************
 // *****************************************************
+//TESTS disabled by default since they take a long time to execute
+//TO enable this tests
+//1. make sure ENV CLFFT_REQUEST_LIB_NOMEMALLOC=1
+//2. pass --gtest_also_run_disabled_tests to TEST.exe
 
 #define CLFFT_TEST_HUGE
 #ifdef CLFFT_TEST_HUGE
@@ -1342,37 +1346,37 @@ void test_name() \
 		catch( const std::exception& err ) { handle_exception(err);	} \
 	}
 
-SP_HUGE_TEST( huge_sp_test_1, 1048576,    11 )
-SP_HUGE_TEST( huge_sp_test_2, 1048576*2,  7  )
-SP_HUGE_TEST( huge_sp_test_3, 1048576*4,  3  )
-SP_HUGE_TEST( huge_sp_test_4, 1048576*8,  5  )
-SP_HUGE_TEST( huge_sp_test_5, 1048576*16, 3  )
-SP_HUGE_TEST( huge_sp_test_6, 1048576*32, 2  )
-SP_HUGE_TEST( huge_sp_test_7, 1048576*64, 1  )
+SP_HUGE_TEST( DISABLED_huge_sp_test_1, 1048576,    11 )
+SP_HUGE_TEST( DISABLED_huge_sp_test_2, 1048576*2,  7  )
+SP_HUGE_TEST( DISABLED_huge_sp_test_3, 1048576*4,  3  )
+SP_HUGE_TEST( DISABLED_huge_sp_test_4, 1048576*8,  5  )
+SP_HUGE_TEST( DISABLED_huge_sp_test_5, 1048576*16, 3  )
+SP_HUGE_TEST( DISABLED_huge_sp_test_6, 1048576*32, 2  )
+SP_HUGE_TEST( DISABLED_huge_sp_test_7, 1048576*64, 1  )
 
-DP_HUGE_TEST( huge_dp_test_1, 524288,    11 )
-DP_HUGE_TEST( huge_dp_test_2, 524288*2,  7  )
-DP_HUGE_TEST( huge_dp_test_3, 524288*4,  3  )
-DP_HUGE_TEST( huge_dp_test_4, 524288*8,  5  )
-DP_HUGE_TEST( huge_dp_test_5, 524288*16, 3  )
-DP_HUGE_TEST( huge_dp_test_6, 524288*32, 2  )
-DP_HUGE_TEST( huge_dp_test_7, 524288*64, 1  )
+DP_HUGE_TEST( DISABLED_huge_dp_test_1, 524288,    11 )
+DP_HUGE_TEST( DISABLED_huge_dp_test_2, 524288*2,  7  )
+DP_HUGE_TEST( DISABLED_huge_dp_test_3, 524288*4,  3  )
+DP_HUGE_TEST( DISABLED_huge_dp_test_4, 524288*8,  5  )
+DP_HUGE_TEST( DISABLED_huge_dp_test_5, 524288*16, 3  )
+DP_HUGE_TEST( DISABLED_huge_dp_test_6, 524288*32, 2  )
+DP_HUGE_TEST( DISABLED_huge_dp_test_7, 524288*64, 1  )
 
-SP_HUGE_TEST( large_sp_test_1, 8192,    11 )
-SP_HUGE_TEST( large_sp_test_2, 8192*2,  7  )
-SP_HUGE_TEST( large_sp_test_3, 8192*4,  3  )
-SP_HUGE_TEST( large_sp_test_4, 8192*8,  5  )
-SP_HUGE_TEST( large_sp_test_5, 8192*16, 3  )
-SP_HUGE_TEST( large_sp_test_6, 8192*32, 21  )
-SP_HUGE_TEST( large_sp_test_7, 8192*64, 17  )
+SP_HUGE_TEST( DISABLED_large_sp_test_1, 8192,    11 )
+SP_HUGE_TEST( DISABLED_large_sp_test_2, 8192*2,  7  )
+SP_HUGE_TEST( DISABLED_large_sp_test_3, 8192*4,  3  )
+SP_HUGE_TEST( DISABLED_large_sp_test_4, 8192*8,  5  )
+SP_HUGE_TEST( DISABLED_large_sp_test_5, 8192*16, 3  )
+SP_HUGE_TEST( DISABLED_large_sp_test_6, 8192*32, 21  )
+SP_HUGE_TEST( DISABLED_large_sp_test_7, 8192*64, 17  )
 
-DP_HUGE_TEST( large_dp_test_1, 4096,    11 )
-DP_HUGE_TEST( large_dp_test_2, 4096*2,  7  )
-DP_HUGE_TEST( large_dp_test_3, 4096*4,  3  )
-DP_HUGE_TEST( large_dp_test_4, 4096*8,  5  )
-DP_HUGE_TEST( large_dp_test_5, 4096*16, 3  )
-DP_HUGE_TEST( large_dp_test_6, 4096*32, 21  )
-DP_HUGE_TEST( large_dp_test_7, 4096*64, 17  )
+DP_HUGE_TEST( DISABLED_large_dp_test_1, 4096,    11 )
+DP_HUGE_TEST( DISABLED_large_dp_test_2, 4096*2,  7  )
+DP_HUGE_TEST( DISABLED_large_dp_test_3, 4096*4,  3  )
+DP_HUGE_TEST( DISABLED_large_dp_test_4, 4096*8,  5  )
+DP_HUGE_TEST( DISABLED_large_dp_test_5, 4096*16, 3  )
+DP_HUGE_TEST( DISABLED_large_dp_test_6, 4096*32, 21  )
+DP_HUGE_TEST( DISABLED_large_dp_test_7, 4096*64, 17  )
 
 #endif
 

--- a/src/tests/accuracy_test_pow2.cpp
+++ b/src/tests/accuracy_test_pow2.cpp
@@ -1298,7 +1298,7 @@ TEST_F(accuracy_test_pow2_double, large_1D_forward_in_place_complex_planar_to_co
 // *****************************************************
 // *****************************************************
 
-//#define CLFFT_TEST_HUGE
+#define CLFFT_TEST_HUGE
 #ifdef CLFFT_TEST_HUGE
 
 #define HUGE_TEST_MAKE(test_name, len, bat) \

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -2038,6 +2038,16 @@ TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_com
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_2)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 2, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_2187_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(2187, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
 
 //interleaved
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -1833,6 +1833,13 @@ void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSiz
 	data_pattern pattern = sawtooth;
 	complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
 }
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_5292_10)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(5292, 10, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
 //177147 = 243 * 243 * 3, backward and forward, planar and interleaved, single and double, batch size 1 and 3
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -1833,182 +1833,185 @@ void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSiz
 	data_pattern pattern = sawtooth;
 	complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
 }
-
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_5292_10)
+//TESTS disabled by default since they take a long time to execute
+//TO enable this tests
+//1. make sure ENV CLFFT_REQUEST_LIB_NOMEMALLOC=1
+//2. pass --gtest_also_run_disabled_tests to TEST.exe
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_5292_10)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(5292, 10, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //177147 = 243 * 243 * 3, backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 //interleaved
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 //1594323 = 729 * 729 * 3 backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
@@ -2016,89 +2019,89 @@ TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_
 
 //14348907 = 2187 * 2187 * 3 backward and forward, planar and interleaved, single and double, batch size 1 and 3
 
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 //interleaved
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_pow3_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_pow3_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -2008,13 +2008,95 @@ TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_
 }
 
 //14348907 = 2187 * 2187 * 3 backward and forward, planar and interleaved, single and double, batch size 1 and 3
-/*
+
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-*/
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+//interleaved
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -1922,96 +1922,7 @@ TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-//78125 = 125 * 125 * 5, backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-//interleaved
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-//1594323 = 729 * 729 * 3 backward and forward, planar and interleaved, single only, double would require 3d transpose (not supported), batch size 1 and 3
+//1594323 = 729 * 729 * 3 backward and forward, planar and interleaved, single and double, batch size 1 and 3
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::forward); }
@@ -2038,15 +1949,20 @@ TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_com
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_2)
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 2, layout::complex_planar, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_2187_1)
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
-	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(2187, 1, layout::complex_planar, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
@@ -2060,7 +1976,6 @@ TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
@@ -2071,54 +1986,35 @@ TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-
-//1953125 = 625 * 625 * 5 backward and forward, planar and interleaved, single only, double would require 3d transpose (not supported), batch size 1 and 3
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
-
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
 
-//interleaved
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+//14348907 = 2187 * 2187 * 3 backward and forward, planar and interleaved, single and double, batch size 1 and 3
+/*
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
-{
-	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::backward); }
-	catch (const std::exception& err) { handle_exception(err); }
-}
-
-
+*/
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -1816,7 +1816,7 @@ TEST_F(accuracy_test_pow3_double, large_1D_out_of_place_hermitian_planar_to_real
 // *****************************************************
 
 template< class T, class cl_T, class fftw_T>
-void huge_1D_forward_in_place_complex_planar_to_complex_planar(size_t lenSize, size_t batchSize, layout::buffer_layout_t layoutType, direction::direction_t direction_type)
+void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSize, layout::buffer_layout_t layoutType, direction::direction_t direction_type)
 {
 	std::vector<size_t> lengths;
 	lengths.push_back(lenSize);
@@ -1836,90 +1836,276 @@ void huge_1D_forward_in_place_complex_planar_to_complex_planar(size_t lenSize, s
 //177147 = 243 * 243 * 3, backward and forward, planar and interleaved, single and double, batch size 1 and 3
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
-	try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 //interleaved
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
-    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
+}
+
+//78125 = 125 * 125 * 5, backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+//interleaved
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1594323 = 729 * 729 * 3 backward and forward, planar and interleaved, single only, double would require 3d transpose (not supported), batch size 1 and 3
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1953125 = 625 * 625 * 5 backward and forward, planar and interleaved, single only, double would require 3d transpose (not supported), batch size 1 and 3
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
 }
 
 

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -1809,6 +1809,69 @@ TEST_F(accuracy_test_pow3_double, large_1D_out_of_place_hermitian_planar_to_real
 }
 
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^ huge 1D ^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+
+// *****************************************************
+// *****************************************************
+
+template< class T, class cl_T, class fftw_T>
+void huge_1D_forward_in_place_complex_planar_to_complex_planar()
+{
+	std::vector<size_t> lengths;
+	lengths.push_back( huge3 );
+	size_t batch = 1;
+	std::vector<size_t> input_strides;
+	std::vector<size_t> output_strides;
+	size_t input_distance = 0;
+	size_t output_distance = 0;
+	layout::buffer_layout_t in_layout = layout::complex_planar;
+	layout::buffer_layout_t out_layout = layout::complex_planar;
+	placeness::placeness_t placeness = placeness::in_place;
+	direction::direction_t direction = direction::forward;
+
+	data_pattern pattern = sawtooth;
+	complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar)
+{
+	try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+template< class T, class cl_T, class fftw_T>
+void huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved()
+{
+	std::vector<size_t> lengths;
+	lengths.push_back(huge3);
+	size_t batch = 1;
+	std::vector<size_t> input_strides;
+	std::vector<size_t> output_strides;
+	size_t input_distance = 0;
+	size_t output_distance = 0;
+	layout::buffer_layout_t in_layout = layout::complex_interleaved;
+	layout::buffer_layout_t out_layout = layout::complex_interleaved;
+	placeness::placeness_t placeness = placeness::in_place;
+	direction::direction_t direction = direction::forward;
+
+	data_pattern pattern = sawtooth;
+	complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved)
+{
+	try { huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved< float, cl_float, fftwf_complex >(); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved)
+{
+	try { huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved< double, cl_double, fftw_complex >(); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 

--- a/src/tests/accuracy_test_pow3.cpp
+++ b/src/tests/accuracy_test_pow3.cpp
@@ -1816,60 +1816,112 @@ TEST_F(accuracy_test_pow3_double, large_1D_out_of_place_hermitian_planar_to_real
 // *****************************************************
 
 template< class T, class cl_T, class fftw_T>
-void huge_1D_forward_in_place_complex_planar_to_complex_planar()
+void huge_1D_forward_in_place_complex_planar_to_complex_planar(size_t lenSize, size_t batchSize, layout::buffer_layout_t layoutType, direction::direction_t direction_type)
 {
 	std::vector<size_t> lengths;
-	lengths.push_back( huge3 );
-	size_t batch = 1;
+	lengths.push_back(lenSize);
+	size_t batch = batchSize;
 	std::vector<size_t> input_strides;
 	std::vector<size_t> output_strides;
 	size_t input_distance = 0;
 	size_t output_distance = 0;
-	layout::buffer_layout_t in_layout = layout::complex_planar;
-	layout::buffer_layout_t out_layout = layout::complex_planar;
+	layout::buffer_layout_t in_layout = layoutType;
+	layout::buffer_layout_t out_layout = layoutType;
 	placeness::placeness_t placeness = placeness::in_place;
-	direction::direction_t direction = direction::forward;
+	direction::direction_t direction = direction_type;
 
 	data_pattern pattern = sawtooth;
 	complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
 }
-
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar)
+//177147 = 243 * 243 * 3, backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
-	try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(); }
+	try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-
-template< class T, class cl_T, class fftw_T>
-void huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved()
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
 {
-	std::vector<size_t> lengths;
-	lengths.push_back(huge3);
-	size_t batch = 1;
-	std::vector<size_t> input_strides;
-	std::vector<size_t> output_strides;
-	size_t input_distance = 0;
-	size_t output_distance = 0;
-	layout::buffer_layout_t in_layout = layout::complex_interleaved;
-	layout::buffer_layout_t out_layout = layout::complex_interleaved;
-	placeness::placeness_t placeness = placeness::in_place;
-	direction::direction_t direction = direction::forward;
-
-	data_pattern pattern = sawtooth;
-	complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved)
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
-	try { huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved< float, cl_float, fftwf_complex >(); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved)
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
-	try { huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved< double, cl_double, fftw_complex >(); }
-	catch (const std::exception& err) { handle_exception(err); }
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
 }
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_1)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_177147_3)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+//interleaved
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+    try { huge_1D_forward_in_place_complex_planar_to_complex_planar< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
 
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //

--- a/src/tests/accuracy_test_pow3_precallback.cpp
+++ b/src/tests/accuracy_test_pow3_precallback.cpp
@@ -1809,6 +1809,165 @@ TEST_F(accuracy_test_pow3_precallback_double, large_1D_out_of_place_hermitian_pl
 }
 
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^ huge 1D ^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+
+// *****************************************************
+// *****************************************************
+
+template< class T, class cl_T, class fftw_T>
+void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSize, layout::buffer_layout_t layoutType, direction::direction_t direction_type)
+{
+	std::vector<size_t> lengths;
+	lengths.push_back(lenSize);
+	size_t batch = batchSize;
+	std::vector<size_t> input_strides;
+	std::vector<size_t> output_strides;
+	size_t input_distance = 0;
+	size_t output_distance = 0;
+	layout::buffer_layout_t in_layout = layoutType;
+	layout::buffer_layout_t out_layout = layoutType;
+	placeness::placeness_t placeness = placeness::in_place;
+	direction::direction_t direction = direction_type;
+
+	data_pattern pattern = sawtooth;
+	precallback_complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
+}
+
+//177147 = 243 * 243 * 3, forward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1594323 = 729 * 729 * 3 foward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//14348907 = 2187 * 2187 * 3 backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 

--- a/src/tests/accuracy_test_pow3_precallback.cpp
+++ b/src/tests/accuracy_test_pow3_precallback.cpp
@@ -1833,135 +1833,139 @@ void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSiz
 	data_pattern pattern = sawtooth;
 	precallback_complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
 }
+//TESTS disabled by default since they take a long time to execute
+//TO enable this tests
+//1. make sure ENV CLFFT_REQUEST_LIB_NOMEMALLOC=1
+//2. pass --gtest_also_run_disabled_tests to TEST.exe
 
 //177147 = 243 * 243 * 3, forward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_177147_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(177147, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //1594323 = 729 * 729 * 3 foward (no need for backward), planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1594323_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1594323, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //14348907 = 2187 * 2187 * 3 backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_pow3_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow3_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
+TEST_F(accuracy_test_pow3_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_14348907_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(14348907, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }

--- a/src/tests/accuracy_test_pow5.cpp
+++ b/src/tests/accuracy_test_pow5.cpp
@@ -2011,6 +2011,94 @@ TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_
     catch (const std::exception& err) { handle_exception(err); }
 }
 
+//48828125 = 3125 * 3125 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //

--- a/src/tests/accuracy_test_pow5.cpp
+++ b/src/tests/accuracy_test_pow5.cpp
@@ -1809,6 +1809,209 @@ TEST_F(accuracy_test_pow5_double, large_1D_out_of_place_hermitian_planar_to_real
 }
 
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^ huge 1D ^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+
+// *****************************************************
+// *****************************************************
+
+template< class T, class cl_T, class fftw_T>
+void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSize, layout::buffer_layout_t layoutType, direction::direction_t direction_type)
+{
+    std::vector<size_t> lengths;
+    lengths.push_back(lenSize);
+    size_t batch = batchSize;
+    std::vector<size_t> input_strides;
+    std::vector<size_t> output_strides;
+    size_t input_distance = 0;
+    size_t output_distance = 0;
+    layout::buffer_layout_t in_layout = layoutType;
+    layout::buffer_layout_t out_layout = layoutType;
+    placeness::placeness_t placeness = placeness::in_place;
+    direction::direction_t direction = direction_type;
+
+    data_pattern pattern = sawtooth;
+    complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
+}
+
+//78125 = 125 * 125 * 5, backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+//interleaved
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1953125 = 625 * 625 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+    try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::backward); }
+    catch (const std::exception& err) { handle_exception(err); }
+}
+
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 

--- a/src/tests/accuracy_test_pow5.cpp
+++ b/src/tests/accuracy_test_pow5.cpp
@@ -1833,622 +1833,626 @@ void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSiz
     data_pattern pattern = sawtooth;
     complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
 }
+//TESTS disabled by default since they take a long time to execute
+//TO enable this tests
+//1. make sure ENV CLFFT_REQUEST_LIB_NOMEMALLOC=1
+//2. pass --gtest_also_run_disabled_tests to TEST.exe
 
 //78125 = 125 * 125 * 5, backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 //interleaved
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 //1953125 = 625 * 625 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
     try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::backward); }
     catch (const std::exception& err) { handle_exception(err); }
 }
 
 //48828125 = 3125 * 3125 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //10,0000 = 100 * 1,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //1,000,000 = 1,000 * 1,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //10,000,000 = 10,000 * 1,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //100,000,000 = 10,000 * 10,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_planar, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+TEST_F(accuracy_test_pow5_single, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
-TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+TEST_F(accuracy_test_pow5_double, DISABLED_huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_interleaved, direction::backward); }
 	catch (const std::exception& err) { handle_exception(err); }

--- a/src/tests/accuracy_test_pow5.cpp
+++ b/src/tests/accuracy_test_pow5.cpp
@@ -2099,6 +2099,362 @@ TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
+//10,0000 = 100 * 1,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1,000,000 = 1,000 * 1,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1000000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_1000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1000000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//10,000,000 = 10,000 * 1,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(10000000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_10000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(10000000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//100,000,000 = 10,000 * 10,000, backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_planar_to_complex_planar_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_planar, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_single, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(100000000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 1, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+TEST_F(accuracy_test_pow5_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_double, huge_1D_backward_in_place_complex_interleaved_to_complex_interleaved_100000000_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(100000000, 3, layout::complex_interleaved, direction::backward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //

--- a/src/tests/accuracy_test_pow5_precallback.cpp
+++ b/src/tests/accuracy_test_pow5_precallback.cpp
@@ -1834,133 +1834,138 @@ void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSiz
 	precallback_complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
 }
 
+//TESTS disabled by default since they take a long time to execute
+//TO enable this tests
+//1. make sure ENV CLFFT_REQUEST_LIB_NOMEMALLOC=1
+//2. pass --gtest_also_run_disabled_tests to TEST.exe
+
 //78125 = 125 * 125 * 5, backward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //1953125 = 625 * 625 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //48828125 = 3125 * 3125 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
 
 //interleaved
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_pow5_precallback_single, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }
 }
-TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+TEST_F(accuracy_test_pow5_precallback_double, DISABLED_huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
 {
 	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
 	catch (const std::exception& err) { handle_exception(err); }

--- a/src/tests/accuracy_test_pow5_precallback.cpp
+++ b/src/tests/accuracy_test_pow5_precallback.cpp
@@ -1809,6 +1809,164 @@ TEST_F(accuracy_test_pow5_precallback_double, large_1D_out_of_place_hermitian_pl
 }
 
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^ huge 1D ^^^^^^^^^^^^^^^^^^^^^^ //
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
+
+// *****************************************************
+// *****************************************************
+
+template< class T, class cl_T, class fftw_T>
+void huge_1D_forward_in_place_complex_to_complex(size_t lenSize, size_t batchSize, layout::buffer_layout_t layoutType, direction::direction_t direction_type)
+{
+	std::vector<size_t> lengths;
+	lengths.push_back(lenSize);
+	size_t batch = batchSize;
+	std::vector<size_t> input_strides;
+	std::vector<size_t> output_strides;
+	size_t input_distance = 0;
+	size_t output_distance = 0;
+	layout::buffer_layout_t in_layout = layoutType;
+	layout::buffer_layout_t out_layout = layoutType;
+	placeness::placeness_t placeness = placeness::in_place;
+	direction::direction_t direction = direction_type;
+
+	data_pattern pattern = sawtooth;
+	precallback_complex_to_complex<T, cl_T, fftw_T>(pattern, direction, lengths, batch, input_strides, output_strides, input_distance, output_distance, in_layout, out_layout, placeness);
+}
+
+//78125 = 125 * 125 * 5, backward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_78125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(78125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//1953125 = 625 * 625 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_1953125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(1953125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//48828125 = 3125 * 3125 * 5 backward and forward, planar and interleaved, single and double, batch size 1 and 3
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_planar_to_complex_planar_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_planar, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+//interleaved
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_single, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< float, cl_float, fftwf_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_1)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 1, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+TEST_F(accuracy_test_pow5_precallback_double, huge_1D_forward_in_place_complex_interleaved_to_complex_interleaved_48828125_3)
+{
+	try { huge_1D_forward_in_place_complex_to_complex< double, cl_double, fftw_complex >(48828125, 3, layout::complex_interleaved, direction::forward); }
+	catch (const std::exception& err) { handle_exception(err); }
+}
+
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^ normal 2D ^^^^^^^^^^^^^^^^^^^^^^ //
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ //
 

--- a/src/tests/test_constants.h
+++ b/src/tests/test_constants.h
@@ -190,7 +190,6 @@ const size_t small3 = 9;
 const size_t normal3 = 729;
 const size_t large3 = 6561;
 const size_t dlarge3 = 2187;
-const size_t huge3 = 729 * 729 * 3;
 
 const size_t small5 = 25;
 const size_t normal5 = 625;

--- a/src/tests/test_constants.h
+++ b/src/tests/test_constants.h
@@ -190,6 +190,7 @@ const size_t small3 = 9;
 const size_t normal3 = 729;
 const size_t large3 = 6561;
 const size_t dlarge3 = 2187;
+const size_t huge3 = 729 * 729 * 3;
 
 const size_t small5 = 25;
 const size_t normal5 = 625;


### PR DESCRIPTION
This PR attempts to enable general in place transpose. Although the algorithms and kernels can handle 2D in place transpose of any size in theory, only matrix sizes where one dimension is 2, 3, 5, 10 times (or a combination of the ratio) of the other dimension are supported and tested due to performance reason. 

257 tests are added to validate the functionality, including pre-callback and post-callback tests. The added tests are disabled by default since they launch some big fft calculations and take relatively long to finish. To run added tests:

1. set ENV to use inplace transpose `CLFFT_REQUEST_LIB_NOMEMALLOC=1`

2. launch gtests with disabled tests such as `Test.exe --gtest_filter=*huge_1D* --gtest_also_run_disabled_tests` should launch all 257 added tests

Both pre-callback and post-callback are supported. Twiddling will also be done within the "transpose" kernels when needed.  

Full suite tests have passed on Hawaii and Fiji device. 

TODO items includes performance validation and optimization and any bug fixes that were not exposed yet in the testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clfft/140)
<!-- Reviewable:end -->
