### PR TITLE
fix typos causing type mismatch in examples

### DIFF
--- a/src/examples/fft1d.c
+++ b/src/examples/fft1d.c
@@ -71,7 +71,7 @@ int main( void )
     X = (float *)malloc(N * 2 * sizeof(*X));
 
     /* print input array */
-    printf("\nPerforming fft on an one dimensional array of size N = %u\n", (unsigned long)N);
+    printf("\nPerforming fft on an one dimensional array of size N = %lu\n", (unsigned long)N);
     int print_iter = 0;
     while(print_iter<N) {
         float x = (float)print_iter;

--- a/src/examples/fft2d.c
+++ b/src/examples/fft2d.c
@@ -74,7 +74,7 @@ int main( void )
 
     /* print input array just using the
      * indices to fill the array with data */
-    printf("\nPerforming fft on an two dimensional array of size N0 x N1 : %u x %u\n", (unsigned long)N0, (unsigned long)N1);
+    printf("\nPerforming fft on an two dimensional array of size N0 x N1 : %lu x %lu\n", (unsigned long)N0, (unsigned long)N1);
 	size_t i, j;
     i = j = 0;
     for (i=0; i<N0; ++i) {

--- a/src/examples/fft3d.c
+++ b/src/examples/fft3d.c
@@ -74,7 +74,7 @@ int main( void )
 
     /* print input array just using the
      * indices to fill the array with data */
-    printf("\nPerforming fft on an two dimensional array of size N0 x N1 x N2 : %u x %u x %u\n", (unsigned long)N0, (unsigned long)N1, (unsigned long)N2);
+    printf("\nPerforming fft on an two dimensional array of size N0 x N1 x N2 : %lu x %lu x %lu\n", (unsigned long)N0, (unsigned long)N1, (unsigned long)N2);
     size_t i, j, k;
     i = j = k = 0;
     for (i=0; i<N0; ++i) {


### PR DESCRIPTION
This resolves a minor compiler warning because the accidental use of `%u` means that an `unsigned  long` is being passed when an `unsigned int` is expected.


(I felt that fixing this directly in a PR would be more efficient than opening an issue about it. I hope that it is alright.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clfft/157)
<!-- Reviewable:end -->
