### PR TITLE
Index calculation in 2D and 3D examples fixed.

### DIFF
--- a/src/examples/fft2d.c
+++ b/src/examples/fft2d.c
@@ -75,13 +75,13 @@ int main( void )
     /* print input array just using the
      * indices to fill the array with data */
     printf("\nPerforming fft on an two dimensional array of size N0 x N1 : %u x %u\n", (unsigned long)N0, (unsigned long)N1);
-	size_t i, j;
+    size_t i, j;
     i = j = 0;
     for (i=0; i<N0; ++i) {
         for (j=0; j<N1; ++j) {
             float x = 0.5f;
             float y = 0.5f;
-			size_t idx = 2*(j+i*N0);
+            size_t idx = 2*(j+i*N1);
             X[idx] = x;
             X[idx+1] = y;
             printf("(%f, %f) ", x, y);
@@ -119,7 +119,7 @@ int main( void )
     i = j = 0;
     for (i=0; i<N0; ++i) {
         for (j=0; j<N1; ++j) {
-			size_t idx = 2*(j+i*N0);
+            size_t idx = 2*(j+i*N1);
             printf("(%f, %f) ", X[idx], X[idx+1]);
         }
         printf("\n");

--- a/src/examples/fft3d.c
+++ b/src/examples/fft3d.c
@@ -85,7 +85,7 @@ int main( void )
                 if (i==0 && j==0 && k==0) {
                     x = y = 0.5f;
                 }
-				size_t idx = 2*(k+j*N1+i*N0*N1);
+                size_t idx = 2*(k+j*N2+i*N1*N2);
                 X[idx] = x;
                 X[idx+1] = y;
                 printf("(%f, %f) ", X[idx], X[idx+1]);
@@ -126,7 +126,7 @@ int main( void )
     for (i=0; i<N0; ++i) {
         for (j=0; j<N1; ++j) {
             for (k=0; k<N2; ++k) {
-				size_t idx = 2*(k+j*N1+i*N0*N1);
+                size_t idx = 2*(k+j*N2+i*N1*N2);
                 printf("(%f, %f) ", X[idx], X[idx+1]);
             }
             printf("\n");


### PR DESCRIPTION
The examples did not support asymmetric data matrices due to wrong index computation.
`j+i*N0` should be `j+i*N1`, since i is walking in [0..N0). Same for 3D example.
This should be compatible to PR #157 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clfft/158)
<!-- Reviewable:end -->
