### PR TITLE
Changed case for URL_MD5 in gtest.cmake

### DIFF
--- a/src/gtest.cmake
+++ b/src/gtest.cmake
@@ -41,7 +41,7 @@ else()
   ExternalProject_Add(
     gtest-external
     URL https://github.com/google/googletest/archive/release-1.7.0.zip
-    URL_MD5 EF5E700C8A0F3EE123E2E0209B8B4961
+    URL_MD5 ef5e700c8a0f3ee123e2e0209b8b4961
     PREFIX ${prefix}
     BINARY_DIR ${binary_dir}
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
This fixes a bug while configuring the project

[  3%] Performing download step (download, verify and extract) for
'gtest-external'
-- downloading...
       src='https://github.com/google/googletest/archive/release-1.7.0.zip'
       dst='D:/Jenkins/jobs/clFFT_From_GitHub/workspace/build/gtest-external-prefix/src/release-1.7.0.zip'
-- [download 0% complete]
...
-- [download 100% complete]
-- verifying file...
       file='D:/Jenkins/jobs/clFFT_From_GitHub/workspace/build/gtest-external-prefix/src/release-1.7.0.zip'
-- MD5 hash of
    D:/Jenkins/jobs/clFFT_From_GitHub/workspace/build/gtest-external-prefix/src/release-1.7.0.zip
does not match expected value
    expected: 'EF5E700C8A0F3EE123E2E0209B8B4961'
      actual: 'ef5e700c8a0f3ee123e2e0209b8b4961'

cmake --version
3.6.1