### PR TITLE
Proper GNU hurd and kFreeBSD support

### DIFF
--- a/src/include/sharedLibrary.h
+++ b/src/include/sharedLibrary.h
@@ -52,7 +52,7 @@ inline void* LoadSharedLibrary( std::string unixPrefix, std::string libraryName,
   {
           std::cerr << ::dlerror( ) << std::endl;
   }
-#elif defined(__FreeBSD_kernel__)
+#elif defined(__FreeBSD__)
         tstring freebsdName = unixPrefix;
         freebsdName += libraryName += ".so";
         void* fileHandle = ::dlopen( freebsdName.c_str( ), RTLD_NOW );

--- a/src/include/sharedLibrary.h
+++ b/src/include/sharedLibrary.h
@@ -36,7 +36,7 @@ inline void* LoadSharedLibrary( std::string unixPrefix, std::string libraryName,
 
 	//	HMODULE is actually the load address; function returns NULL if it cannot find the shared library
 	HMODULE fileHandle	= ::LoadLibraryExA( libraryName.c_str( ), NULL, NULL );
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
         tstring linuxName = unixPrefix;
 	linuxName += libraryName += ".so";
 	void* fileHandle = ::dlopen( linuxName.c_str( ), RTLD_NOW );


### PR DESCRIPTION
This PR provides a better patch to support building clFFT on the GNU/kFreeBSD and GNU/Hurd Debian ports. I reverted the initial one I submitted some time ago to start afresh.

The second commit is the recommended patch for introducing support for both architectures alongside Linux. The `__linux__` macro alone does not cover these architectures, although both can use `dlopen` in the same way as Linux does. The additional macros allows this code path to be followed by builds on the GNU Hurd and kFreeBSD architectures.

FYI, this is the same patch as the one submitted to `clSPARSE` [here](https://github.com/clMathLibraries/clSPARSE/pull/201) for a similar feature.

Cheers,