### PR TITLE
Fix MinGW unicode compilation bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,6 +239,11 @@ if( MSVC AND UNICODE )
 	add_definitions( "/DUNICODE /D_UNICODE" )
 endif( )
 
+# If UNICODE is defined for MinGW compilers, pass extra definitions
+if( MINGW AND UNICODE )
+	add_definitions( "-DUNICODE -D_UNICODE" )
+endif( )
+
 # Print out compiler flags for viewing/debug
 message( STATUS "CMAKE_CXX_COMPILER flags: " ${CMAKE_CXX_FLAGS} )
 message( STATUS "CMAKE_CXX_COMPILER debug flags: " ${CMAKE_CXX_FLAGS_DEBUG} )


### PR DESCRIPTION
This fixes a unicode bug that causes MinGW compilation to fail by adding the the extra unicode  definitions for MinGW similar to how they are added for MSVC. This makes it build at least on MSYS2 MinGW64 G++ 6.3.0.

Bug in question:
fft_binary_lookup.cpp: In member function 'bool FFTBinaryLookup::CacheEntry::exclusive_create()':
fft_binary_lookup.cpp:129:36: error: cannot convert 'const wchar_t*' to'LPCSTR {aka const char*}' for argument '1' to 'void* CreateFileA(LPCSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD,
HANDLE)'
NULL);

Short test log:
https://gist.github.com/polyZealous/88719c00e5fd4518a9135f64b4c78c90#file-mingw_clfft_test_log-txt