### PR TITLE
Cast before and after call to `sqrt`

### DIFF
--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -165,7 +165,7 @@ static bool split1D_for_inplace(size_t num, vector<vector<size_t> > &splitNums, 
 
 	num = num / divide_factor;
 	//now the remaining num should have even number of pow2, pow3 and pow5 and we can do sqrt
-	size_t temp = sqrt(num);
+	size_t temp = (size_t)sqrt((double)num);
 	vector<size_t> splitVec;
 	splitVec.push_back(temp*divide_factor);
 	splitVec.push_back(temp);


### PR DESCRIPTION
Fixes https://github.com/clMathLibraries/clFFT/issues/198

A call to `sqrt` was taking a `size_t` value as input and expecting a `size_t` value as output. This kind of works with C++11, but only with C++11. Even then a `double` is the expected return type. To fix this issue, we convert to a `double` start with. Also as we should have a perfect square going into `sqrt`, we expect to have an integral value coming out (though of `double` type). So we round to get rid of any floating point arithmetic oddness. Then we cast back to `size_t` explicitly to match our intended storage type.