### PR TITLE
BACKPORT: Cast before and after call to `sqrt`

### DIFF
--- a/src/library/plan.cpp
+++ b/src/library/plan.cpp
@@ -165,7 +165,7 @@ static bool split1D_for_inplace(size_t num, vector<vector<size_t> > &splitNums, 
 
 	num = num / divide_factor;
 	//now the remaining num should have even number of pow2, pow3 and pow5 and we can do sqrt
-	size_t temp = sqrt(num);
+	size_t temp = (size_t)sqrt((double)num);
 	vector<size_t> splitVec;
 	splitVec.push_back(temp*divide_factor);
 	splitVec.push_back(temp);


### PR DESCRIPTION
Backports the change from PR ( https://github.com/clMathLibraries/clFFT/pull/199 ) to `master`.