### PR TITLE
Fixed static instantiation issue on (at least) Windows.

### DIFF
--- a/src/library/lifetime.cpp
+++ b/src/library/lifetime.cpp
@@ -29,7 +29,7 @@ clfftStatus	clfftSetup( const clfftSetupData* sData )
 {
 	//	Static data is not thread safe (to create), so we implement a lock to protect instantiation for the first call
 	//	Implemented outside of FFTRepo::getInstance to minimize lock overhead; this is only necessary on first creation
-	scopedLock sLock( FFTRepo::lockRepo, _T( "FFTRepo::getInstance" ) );
+	scopedLock sLock( FFTRepo::lockRepo(), _T( "FFTRepo::getInstance" ) );
 
 	//	First invocation of this function will allocate the FFTRepo singleton; thereafter the object always exists
 	FFTRepo& fftRepo	= FFTRepo::getInstance( );

--- a/src/library/repo.cpp
+++ b/src/library/repo.cpp
@@ -24,9 +24,6 @@
 using std::map;
 using std::string;
 
-//	Static initialization of the repo lock variable
-lockRAII FFTRepo::lockRepo( _T( "FFTRepo" ) );
-
 //	Static initialization of the plan count variable
 size_t FFTRepo::planCount	= 1;
 
@@ -39,7 +36,7 @@ GpuStatTimer* FFTRepo::pStatTimer	= NULL;
 
 clfftStatus FFTRepo::releaseResources( )
 {
-	scopedLock sLock( lockRepo, _T( "releaseResources" ) );
+	scopedLock sLock( lockRepo(), _T( "releaseResources" ) );
 
 	//	Release all handles to Kernels
 	//
@@ -110,7 +107,7 @@ clfftStatus FFTRepo::releaseResources( )
 
 clfftStatus FFTRepo::setProgramCode( const clfftGenerators gen, const FFTKernelSignatureHeader * data, const std::string& kernel, const cl_device_id &device, const cl_context& planContext )
 {
-	scopedLock sLock( lockRepo, _T( "setProgramCode" ) );
+	scopedLock sLock( lockRepo(), _T( "setProgramCode" ) );
 
 	FFTRepoKey key(gen, data, planContext, device);
 
@@ -145,7 +142,7 @@ clfftStatus FFTRepo::setProgramCode( const clfftGenerators gen, const FFTKernelS
 
 clfftStatus FFTRepo::getProgramCode( const clfftGenerators gen, const FFTKernelSignatureHeader * data, std::string& kernel, const cl_device_id &device, const cl_context& planContext )
 {
-	scopedLock sLock( lockRepo, _T( "getProgramCode" ) );
+	scopedLock sLock( lockRepo(), _T( "getProgramCode" ) );
 
 	FFTRepoKey key(gen, data, planContext, device);
 
@@ -160,7 +157,7 @@ clfftStatus FFTRepo::getProgramCode( const clfftGenerators gen, const FFTKernelS
 clfftStatus FFTRepo::setProgramEntryPoints( const clfftGenerators gen, const FFTKernelSignatureHeader * data,
 	const char * kernel_fwd, const char * kernel_back, const cl_device_id &device, const cl_context& planContext  )
 {
-	scopedLock sLock( lockRepo, _T( "setProgramEntryPoints" ) );
+	scopedLock sLock( lockRepo(), _T( "setProgramEntryPoints" ) );
 
 	FFTRepoKey key(gen, data, planContext, device);
 
@@ -174,7 +171,7 @@ clfftStatus FFTRepo::setProgramEntryPoints( const clfftGenerators gen, const FFT
 clfftStatus FFTRepo::getProgramEntryPoint( const clfftGenerators gen, const FFTKernelSignatureHeader * data,
 			clfftDirection dir, std::string& kernel, const cl_device_id &device, const cl_context& planContext )
 {
-	scopedLock sLock( lockRepo, _T( "getProgramEntryPoint" ) );
+	scopedLock sLock( lockRepo(), _T( "getProgramEntryPoint" ) );
 
 	FFTRepoKey key(gen, data, planContext, device);
 
@@ -202,7 +199,7 @@ clfftStatus FFTRepo::getProgramEntryPoint( const clfftGenerators gen, const FFTK
 
 clfftStatus FFTRepo::setclProgram( const clfftGenerators gen, const FFTKernelSignatureHeader * data, const cl_program& prog, const cl_device_id &device, const cl_context& planContext )
 {
-	scopedLock sLock( lockRepo, _T( "setclProgram" ) );
+	scopedLock sLock( lockRepo(), _T( "setclProgram" ) );
 
  	FFTRepoKey key(gen, data, planContext, device);
 
@@ -225,7 +222,7 @@ clfftStatus FFTRepo::setclProgram( const clfftGenerators gen, const FFTKernelSig
 
 clfftStatus FFTRepo::getclProgram( const clfftGenerators gen, const FFTKernelSignatureHeader * data, cl_program& prog, const cl_device_id &device, const cl_context& planContext  )
 {
-	scopedLock sLock( lockRepo, _T( "getclProgram" ) );
+	scopedLock sLock( lockRepo(), _T( "getclProgram" ) );
 
 	FFTRepoKey key(gen, data, planContext, device);
 
@@ -246,7 +243,7 @@ clfftStatus FFTRepo::getclProgram( const clfftGenerators gen, const FFTKernelSig
 
 clfftStatus FFTRepo::setclKernel( cl_program prog, clfftDirection dir, const cl_kernel& kernel )
 {
-	scopedLock sLock( lockRepo, _T( "setclKernel" ) );
+	scopedLock sLock( lockRepo(), _T( "setclKernel" ) );
 
 	fftKernels & Kernels = mapKernels[ prog ];
 
@@ -283,7 +280,7 @@ clfftStatus FFTRepo::setclKernel( cl_program prog, clfftDirection dir, const cl_
 
 clfftStatus FFTRepo::getclKernel( cl_program prog, clfftDirection dir, cl_kernel& kernel, lockRAII*& kernelLock)
 {
-	scopedLock sLock( lockRepo, _T( "getclKernel" ) );
+	scopedLock sLock( lockRepo(), _T( "getclKernel" ) );
 
 	Kernel_iterator pos = mapKernels.find( prog );
 	if (pos == mapKernels.end( ) )
@@ -311,7 +308,7 @@ clfftStatus FFTRepo::getclKernel( cl_program prog, clfftDirection dir, cl_kernel
 
 clfftStatus FFTRepo::createPlan( clfftPlanHandle* plHandle, FFTPlan*& fftPlan )
 {
-	scopedLock sLock( lockRepo, _T( "insertPlan" ) );
+	scopedLock sLock( lockRepo(), _T( "insertPlan" ) );
 
 	//	We keep track of this memory in our own collection class, to make sure it's freed in releaseResources
 	//	The lifetime of a plan is tracked by the client and is freed when the client calls ::clfftDestroyPlan()
@@ -332,7 +329,7 @@ clfftStatus FFTRepo::createPlan( clfftPlanHandle* plHandle, FFTPlan*& fftPlan )
 
 clfftStatus FFTRepo::getPlan( clfftPlanHandle plHandle, FFTPlan*& fftPlan, lockRAII*& planLock )
 {
-	scopedLock sLock( lockRepo, _T( "getPlan" ) );
+	scopedLock sLock( lockRepo(), _T( "getPlan" ) );
 
 	//	First, check if we have already created a plan with this exact same FFTPlan
 	repoPlansType::iterator iter	= repoPlans.find( plHandle );
@@ -348,7 +345,7 @@ clfftStatus FFTRepo::getPlan( clfftPlanHandle plHandle, FFTPlan*& fftPlan, lockR
 
 clfftStatus FFTRepo::deletePlan( clfftPlanHandle* plHandle )
 {
-	scopedLock sLock( lockRepo, _T( "deletePlan" ) );
+	scopedLock sLock( lockRepo(), _T( "deletePlan" ) );
 
 	//	First, check if we have already created a plan with this exact same FFTPlan
 	repoPlansType::iterator iter	= repoPlans.find( *plHandle );

--- a/src/library/repo.h
+++ b/src/library/repo.h
@@ -183,8 +183,14 @@ public:
 	//	Used to make the FFTRepo struct thread safe; STL is not thread safe by default
 	//	Optimally, we could use a lock object per STL struct, as two different STL structures
 	//	can be modified at the same time, but a single lock object is easier and performance should
-	//	still be good
-	static lockRAII lockRepo;
+	//	still be good. This is implemented as a function returning a static local reference to
+	//	assert that the lock must be instantiated before the result can be used.
+	static lockRAII& lockRepo()
+	{
+		//	Static initialization of the repo lock variable
+		static lockRAII lock(_T("FFTRepo"));
+		return lock;
+	}
 
 	//	Our runtime library can instrument kernel timings with a GPU timer available in a shared module
 	//	Handle/Address of the dynamic module that contains timers


### PR DESCRIPTION
Previously, the static initialization of FFTRepo::lockRepo in some cases could be uninitialized before the call to clfftSetup was called. This lead to much crashing.

Now, the static function FFTRepo::lockRepo() returns a reference to the local static variable lock. This asserts that the result of lockRepo() must be instantiated in all cases. This also maintains the original intent of lockRepo.