### PR TITLE
Fix compilation warnings on Vega architecture

### DIFF
--- a/src/library/generator.stockham.cpp
+++ b/src/library/generator.stockham.cpp
@@ -3905,7 +3905,7 @@ namespace StockhamGenerator
 							if(inInterleaved || inReal)
 							{
 								if(!rcSimple) {	str += "lwbIn2 = gbIn + iOffset2;\n\t"; }
-								str += "lwbIn = gbIn + iOffset;\n\t"; 
+								str += "lwbIn = (__global float2 *) gbIn + iOffset;\n\t";
 							}
 							else
 							{
@@ -3981,7 +3981,7 @@ namespace StockhamGenerator
 						{
 							if(inInterleaved)
 							{
-								str += "lwbIn = gbIn + iOffset;\n\t";
+								str += "lwbIn = (__global float2 *) gbIn + iOffset;\n\t";
 							}
 							else
 							{

--- a/src/library/generator.stockham.cpp
+++ b/src/library/generator.stockham.cpp
@@ -3488,9 +3488,14 @@ namespace StockhamGenerator
         clGetDeviceInfo(Dev_ID, CL_DEVICE_VENDOR, 0, NULL, &SizeParam_ret);
         char* nameVendor = new char[SizeParam_ret];
         clGetDeviceInfo(Dev_ID, CL_DEVICE_VENDOR, SizeParam_ret, nameVendor, NULL);
+        char nameDevice[128];
+        clGetDeviceInfo(Dev_ID, CL_DEVICE_NAME, SizeParam_ret, nameDevice, NULL);
 
         //nv compiler doesn't support __constant kernel argument
-        if (strncmp(nameVendor, "NVIDIA",6)!=0)
+        //rocm compiler (for Vega) doesn't support __constant kernel argument
+        if ((strncmp(nameVendor, "NVIDIA",6)!=0) &&
+            (strncmp(nameVendor, "Advanced Micro Devices, Inc.", 28) != 0 &&
+             strncmp(nameDevice, "gfx900", 6) != 0))
           str += "__constant cb_t *cb __attribute__((max_constant_size(32))), ";
         else
           str += "__global cb_t *cb, ";


### PR DESCRIPTION
When using clFFT on Fedora 26 using the 2515.0 ROCm driver and a Vega Frontier Edition GPU, I get two runtime errors:
```
/tmp/AMD_37850_19/t_37850_21.cl:324:49: warning: unknown attribute 'max_constant_size' ignored [-Wunknown-attributes]
void fft_fwd(__constant cb_t *cb __attribute__((max_constant_size(32))), __global const float2 * restrict gbIn...
                                                ^
```
And:
```
/tmp/AMD_37850_19/t_37850_21.cl:344:8: warning: assigning to '__global float2 *' from 'const __global float2 *'
      discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
      lwbIn = gbIn + iOffset;
              ^ ~~~~~~~~~~~~~~
```
These warnings are easily resolved by minor code changes.