### PR TITLE
Generate debian package as well as tgz

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,11 +107,11 @@ set( SUFFIX_LIB_DEFAULT "" )
 set( SUFFIX_BIN_DEFAULT "" )
 
 # Modify the global find property to help us find libraries like Boost in the correct paths for 64-bit
-# Essentially, find_library calls will look for /lib64 instead of /lib; works for windows and linux
+# Essentially, find_library calls will look for /lib64 instead of /lib; works for windows, not on debian
 if( BUILD64 )
 	set_property( GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE )
 	message( STATUS "64bit build - FIND_LIBRARY_USE_LIB64_PATHS TRUE" )
-	if( NOT APPLE )
+	if( WIN32 )
 		set( SUFFIX_LIB_DEFAULT "64" )
 	endif()
 else( )
@@ -320,12 +320,15 @@ install( FILES ${CMAKE_CURRENT_BINARY_DIR}/clFFTConfigVersion.cmake
 	${CMAKE_CURRENT_BINARY_DIR}/clFFTConfig.cmake
 	DESTINATION ${destdir} )
 
+install( FILES ${CMAKE_SOURCE_DIR}/FindclFFT.cmake
+	DESTINATION ${destdir} )
+
 # The following code is setting variables to control the behavior of CPack to generate our
 set(CPACK_PACKAGE_NAME "clFFT")
 set(CPACK_PACKAGE_VENDOR "AMD")
 set(CPACK_PACKAGE_DESCRIPTION "A software library containing FFT functions written in OpenCL")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "FFT in OpenCL")
-set(CPACK_PACKAGE_CONTACT "none@gmail.com")
+#set(CPACK_PACKAGE_CONTACT "none@gmail.com")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/../LICENSE")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/../README.md")
 
@@ -339,7 +342,8 @@ else( )
 	set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_VENDOR} <${CPACK_PACKAGE_CONTACT}>")
 	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${CPACK_SYSTEM_NAME}")
 	set(CPACK_DEBIAN_PACKAGE_SECTION "libdevel")
-	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libc++1, ocl-icd-opencl-dev")
+	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, ocl-icd-opencl-dev")
+	set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "cmake")
 	#set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "debian/conffiles")
 endif( )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -321,12 +321,26 @@ install( FILES ${CMAKE_CURRENT_BINARY_DIR}/clFFTConfigVersion.cmake
 	DESTINATION ${destdir} )
 
 # The following code is setting variables to control the behavior of CPack to generate our
+set(CPACK_PACKAGE_NAME "clFFT")
+set(CPACK_PACKAGE_VENDOR "AMD")
+set(CPACK_PACKAGE_DESCRIPTION "A software library containing FFT functions written in OpenCL")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "FFT in OpenCL")
+set(CPACK_PACKAGE_CONTACT "none@gmail.com")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/../LICENSE")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/../README.md")
+
 if( WIN32 )
 	set( CPACK_SOURCE_GENERATOR "ZIP" )
 	set( CPACK_GENERATOR "ZIP" )
 else( )
-	set( CPACK_SOURCE_GENERATOR "TGZ" )
-	set( CPACK_GENERATOR "TGZ" )
+	set( CPACK_SOURCE_GENERATOR "TGZ;DEB" )
+	set( CPACK_GENERATOR "TGZ;DEB" )
+
+	set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_VENDOR} <${CPACK_PACKAGE_CONTACT}>")
+	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${CPACK_SYSTEM_NAME}")
+	set(CPACK_DEBIAN_PACKAGE_SECTION "libdevel")
+	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libc++1, ocl-icd-opencl-dev")
+	#set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "debian/conffiles")
 endif( )
 
 if( BUILD64 )

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ########################################################################
 
+find_package(Threads REQUIRED)
+
 INCLUDE_DIRECTORIES(
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${OpenCL_INCLUDE_DIRS}"
@@ -40,7 +42,16 @@ FOREACH(FILE ${FILES})
     SET(EXAMPLE_NAME example_${DIR_NAME}_${EXAMPLE})
     ADD_EXECUTABLE(${EXAMPLE_NAME} ${FILE})
 
-    TARGET_LINK_LIBRARIES(${EXAMPLE_NAME} clFFT ${OpenCL_LIBRARIES} ${CMAKE_DL_LIBS})
+    TARGET_LINK_LIBRARIES(${EXAMPLE_NAME} clFFT
+		${OpenCL_LIBRARIES}
+		${CMAKE_DL_LIBS}
+	)
+
+	if(UNIX)
+		TARGET_LINK_LIBRARIES(${EXAMPLE_NAME} clFFT
+			Threads::Threads
+		)
+	endif()
 
     SET_TARGET_PROPERTIES(${EXAMPLE_NAME}
         PROPERTIES

--- a/src/library/enqueue.cpp
+++ b/src/library/enqueue.cpp
@@ -97,6 +97,12 @@ FFTAction::FFTAction(FFTPlan * fftPlan, clfftStatus & err)
     err = CLFFT_SUCCESS;
 }
 
+
+FFTAction::~FFTAction()
+{
+}
+
+
 clfftStatus FFTAction::selectBufferArguments(FFTPlan * fftPlan,
                                              cl_mem* clInputBuffers,
                                              cl_mem* clOutputBuffers,

--- a/src/library/plan.h
+++ b/src/library/plan.h
@@ -330,6 +330,8 @@ class FFTAction
 public:
     FFTAction(FFTPlan * plan, clfftStatus & err);
 
+	virtual ~FFTAction();
+
     virtual clfftStatus enqueue(clfftPlanHandle plHandle,
                                 clfftDirection dir,
                                 cl_uint numQueuesAndEvents,


### PR DESCRIPTION
In order to keep my system maintainable, I'd like to install clFFT using the package manager.
(In this case debian).

This PR adds CMake commands to generate the .deb, and fixes a linking error of the examples.