### PR TITLE
Handle NaNs

### DIFF
--- a/src/tests/buffer.h
+++ b/src/tests/buffer.h
@@ -536,7 +536,8 @@ private:
 
 				rms = sqrt(rms*maxMagInv);
 
-				if (fabs(rms) > rmse_tolerance_this)
+				if (fabs(rms) <= rmse_tolerance_this) {}
+				else
 				{
 					if (suppress_output == false)
 						std::cout << std::endl << "RMSE accuracy judgement failure -- RMSE = " << std::dec << rms <<
@@ -1067,7 +1068,7 @@ public:
 					// if there are an odd number of points in the whole period,
 					// we'll make a stop at 0 in the middle of the jump
 					T value = 0.0f;
-					T per_point_delta = amplitude / (number_of_points_on_one_line - 1);
+					T per_point_delta = amplitude / (number_of_points_on_one_line > 1 ? number_of_points_on_one_line - 1 : 1);
 
 					for( size_t x = 0; x < number_of_points_in_one_period; x++) {
 						if( is_real() )


### PR DESCRIPTION
1 Treat NaNs as error in RMSE accuracy measurements
Comparison with NaN always goes to false-case of if-statement, but tolerance errors are reported in true-case of if-statement. So, RMSE equals NAN was always hidden, and faulty tests might pass.

2 set_all_to_sawtooth method generates infinities in case length(dimx) == 2, this results in NaNs being the results of FFT.