### PR TITLE
Fix memory leak when deleting base object without virtual destructor

### DIFF
--- a/src/library/plan.h
+++ b/src/library/plan.h
@@ -329,6 +329,7 @@ class FFTAction
 {
 public:
     FFTAction(FFTPlan * plan, clfftStatus & err);
+    virtual ~FFTAction() {}
 
     virtual clfftStatus enqueue(clfftPlanHandle plHandle,
                                 clfftDirection dir,


### PR DESCRIPTION
Fix for `AddressSanitizer` discovered `new-delete-type-mismatch`. Deleting an object of a derived class through its base class without a virtual destructor results in undefined behavior.

```
~/Desktop/clFFT/src/build$ ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.4 LD_LIBRARY_PATH=library/ examples/examples/fft1d X server found. dri2 connection failed! 
Platform found: Intel(R) OpenCL
Device found on the above platform: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz

Performing fft on an one dimensional array of size N = 16
(0.000000, 0.000000) (1.000000, 3.000000) (2.000000, 6.000000) (3.000000, 9.000000) (4.000000, 12.000000) (5.000000, 15.000000) (6.000000, 18.000000) (7.000000, 21.000000) (8.000000, 24.000000) (9.000000, 27.000000) (10.000000, 30.000000) (11.000000, 33.000000) (12.000000, 36.000000) (13.000000, 39.000000) (14.000000, 42.000000) (15.000000, 45.000000) 

fft result: 
(120.000000, 360.000000) (-128.656143, 16.218718) (-65.941124, -4.686291) (-43.918537, -12.027153) (-32.000000, -16.000000) (-24.036289, -18.654572) (-17.941124, -20.686291) (-12.773895, -22.408699) (-8.000000, -24.000000) (-3.226101, -25.591299) (1.941124, -27.313709) (8.036289, -29.345428) (16.000000, -32.000000) (27.918537, -35.972847) (49.941124, -43.313709) (112.656143, -64.218719) 
=================================================================
==25530==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x61600001f580 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   616 bytes;
  size of the deallocated type: 16 bytes.
    #0 0x7fd8c84fe9d8 in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe19d8)
    #1 0x7fd8c817168b in FFTRepo::deletePlan(unsigned long*) (library/libclFFT.so.2+0x2f68b)
    #2 0x7fd8c8160da4 in clfftDestroyPlan (library/libclFFT.so.2+0x1eda4)
    #3 0x556b73007430 in main (~/Desktop/clFFT/src/build/examples/examples/fft1d+0x1430)
    #4 0x7fd8c795c1c0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x211c0)
    #5 0x556b730074a9 in _start (~/Desktop/clFFT/src/build/examples/examples/fft1d+0x14a9)

0x61600001f580 is located 0 bytes inside of 616-byte region [0x61600001f580,0x61600001f7e8)
allocated by thread T0 here:
    #0 0x7fd8c84fd458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7fd8c8160ba9 in selectAction(FFTPlan*, FFTAction*&, _cl_command_queue**) (library/libclFFT.so.2+0x1eba9)

SUMMARY: AddressSanitizer: new-delete-type-mismatch (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe19d8) in operator delete(void*, unsigned long)
==25530==HINT: if you don't care about these errors you may set ASAN_OPTIONS=new_delete_type_mismatch=0
==25530==ABORTING
```